### PR TITLE
WTEL-9760: Add dynamic http_proxy/no_proxy module

### DIFF
--- a/infra/httpproxy/README.md
+++ b/infra/httpproxy/README.md
@@ -1,0 +1,81 @@
+# httpproxy
+
+Hot-reloadable forward-proxy settings (`http_proxy` / `https_proxy` / `no_proxy`)
+for outbound HTTP clients. Lets a service pick up proxy changes at runtime —
+no restart — which the standard environment variables cannot do (a process
+environment is fixed at startup).
+
+## How it works
+
+`Manager` keeps the current settings in an atomic snapshot and exposes
+`Manager.Proxy`, a function assignable to `http.Transport.Proxy`. The
+transport consults it **on every request**, so long-lived clients follow
+settings changes without being rebuilt. After every applied change the
+manager calls `CloseIdleConnections()` on all registered transports, so
+pooled keep-alive connections do not keep using the previous route.
+
+Settings come from a small watched YAML file, with the process environment
+as the fallback. The watch is on the parent directory and any event there
+triggers a debounced reload (unchanged settings are a no-op), so
+rename-replace updates and even
+replacement of the directory itself are picked up; watcher setup failures
+are logged, never silent.
+
+## Quick start
+
+```go
+mgr := httpproxy.NewManager(httpproxy.WithLogger(log))
+
+// Make http.Get, http.DefaultClient and SDKs on the default transport dynamic.
+if err := mgr.HookDefaultTransport(); err != nil {
+    return err
+}
+
+// Apply and watch the settings file; empty path keeps environment settings.
+go mgr.WatchFile(ctx, os.Getenv("PROXY_CONFIG_FILE"))
+```
+
+Custom transports:
+
+```go
+shared := mgr.Transport()                 // clone of http.DefaultTransport; create once and reuse
+client := mgr.Client(15 * time.Second)    // safe to call per request: one shared transport inside
+custom := mgr.WrapTransport(&http.Transport{TLSClientConfig: tlsCfg})
+```
+
+`Transport()`/`WrapTransport()` register the transport for the manager's
+lifetime — create them once and share. Short-lived per-request transports
+should set `Proxy: mgr.Proxy` directly and must **not** be registered.
+
+## Settings file
+
+YAML (JSON is accepted too, being a YAML subset):
+
+```yaml
+http_proxy: "http://user:pass@10.0.1.1:3128"
+https_proxy: "http://10.0.1.1:3128"
+no_proxy: "localhost,127.0.0.1,.svc,10.0.0.0/8"
+```
+
+| State | Effect |
+|---|---|
+| Key absent | Falls back to the environment variable (`HTTP_PROXY`, …) |
+| Key set to `""` | Explicitly no proxy for that class of requests |
+| File missing / deleted | Plain environment behavior |
+| Misspelled key, malformed file, URL without host, bad `no_proxy` CIDR/IP | Logged (credentials redacted); last good settings stay in effect |
+
+`no_proxy` matching follows `golang.org/x/net/http/httpproxy`: host names,
+domain suffixes (`.example.com`), IPs and CIDRs; `*` disables proxying.
+Requests to `localhost` and loopback addresses are always direct.
+
+## Caveats
+
+- `HookDefaultTransport` must run early in `main()`, before any outbound
+  request and before any code clones `http.DefaultTransport`.
+- Changing the settings re-routes **new** requests; in-flight requests finish
+  on the connection they started with.
+- HTTP CONNECT proxying applies to plain-HTTP and TLS (including HTTP/2 via
+  CONNECT). Raw-TCP protocols (gRPC dialers, MTProto) are out of scope.
+- Services using `appconfig` can wire the manager to their config reload by
+  calling `mgr.Update(cfg)` from `Loader.Watch`; a canonical `appconfig.Proxy`
+  section can be added once such a service needs outbound HTTP.

--- a/infra/httpproxy/config.go
+++ b/infra/httpproxy/config.go
@@ -1,0 +1,183 @@
+package httpproxy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	xproxy "golang.org/x/net/http/httpproxy"
+)
+
+// Config is the effective set of forward-proxy rules for outbound HTTP
+// requests. Field semantics match the conventional HTTP_PROXY / HTTPS_PROXY /
+// NO_PROXY environment variables (see golang.org/x/net/http/httpproxy):
+// an empty value means "no proxy" for that class of requests.
+type Config struct {
+	// HTTPProxy is the proxy URL used for http:// requests.
+	// A bare "host:port" is accepted and treated as an http:// URL.
+	HTTPProxy string `yaml:"http_proxy" json:"http_proxy"`
+	// HTTPSProxy is the proxy URL used for https:// requests.
+	HTTPSProxy string `yaml:"https_proxy" json:"https_proxy"`
+	// NoProxy is a comma-separated list of hosts, domain suffixes
+	// (".example.com"), IPs and CIDRs ("10.0.0.0/8") that are always
+	// reached directly, bypassing the proxy. A single "*" disables
+	// proxying entirely.
+	NoProxy string `yaml:"no_proxy" json:"no_proxy"`
+}
+
+// FromEnvironment returns the proxy settings of the current process
+// environment: HTTP_PROXY, HTTPS_PROXY and NO_PROXY, or their lowercase
+// variants. Note that the process environment cannot change at runtime;
+// for on-the-fly updates use Manager.WatchFile or Manager.Update.
+func FromEnvironment() Config {
+	env := xproxy.FromEnvironment()
+	return Config{
+		HTTPProxy:  env.HTTPProxy,
+		HTTPSProxy: env.HTTPSProxy,
+		NoProxy:    env.NoProxy,
+	}
+}
+
+// Validate reports whether the settings are usable. It exists because
+// golang.org/x/net/http/httpproxy silently tolerates malformed values,
+// which would turn a typo in the config into "no proxy" or a garbage host —
+// Manager.Update rejects such configs instead, keeping the last good
+// settings. It is deliberately stricter than x/net: proxy URLs must carry a
+// non-empty host, and no_proxy entries that look like CIDRs or IPs must
+// parse as such. Error messages never contain proxy credentials.
+func (c Config) Validate() error {
+	if _, err := parseProxyURL(c.HTTPProxy); err != nil {
+		return fmt.Errorf("httpproxy: http_proxy: %w", err)
+	}
+	if _, err := parseProxyURL(c.HTTPSProxy); err != nil {
+		return fmt.Errorf("httpproxy: https_proxy: %w", err)
+	}
+	if err := validateNoProxy(c.NoProxy); err != nil {
+		return fmt.Errorf("httpproxy: no_proxy: %w", err)
+	}
+	return nil
+}
+
+// proxyFunc compiles the config into a per-URL proxy resolver with the
+// standard no_proxy matching semantics.
+func (c Config) proxyFunc() func(*url.URL) (*url.URL, error) {
+	x := xproxy.Config{
+		HTTPProxy:  c.HTTPProxy,
+		HTTPSProxy: c.HTTPSProxy,
+		NoProxy:    c.NoProxy,
+		CGI:        os.Getenv("REQUEST_METHOD") != "",
+	}
+	return x.ProxyFunc()
+}
+
+// parseProxyURL mirrors the tolerant parsing of
+// golang.org/x/net/http/httpproxy — an empty value means no proxy and a bare
+// "host:port" is treated as an http:// proxy URL — and additionally rejects
+// addresses without a host, which x/net would silently turn into a broken
+// proxy.
+func parseProxyURL(addr string) (*url.URL, error) {
+	if addr == "" {
+		return nil, nil
+	}
+	if strings.ContainsAny(addr, " \t\r\n") {
+		return nil, fmt.Errorf("invalid proxy address %q: contains whitespace", redactAddr(addr))
+	}
+	proxyURL, err := url.Parse(addr)
+	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
+		proxyURL, err = url.Parse("http://" + addr)
+	}
+	if err != nil {
+		// Unwrap url.Error: its message embeds the raw URL, credentials
+		// included.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err
+		}
+		return nil, fmt.Errorf("invalid proxy address %q: %w", redactAddr(addr), err)
+	}
+	if proxyURL.Hostname() == "" || strings.HasSuffix(proxyURL.Host, ":") {
+		return nil, fmt.Errorf("invalid proxy address %q: missing host", redactAddr(addr))
+	}
+	return proxyURL, nil
+}
+
+// validateNoProxy rejects the realistic typos that x/net would silently
+// drop: entries with "/" must be valid CIDRs, and entries that look like an
+// IP must parse as one. Hostnames and domain suffixes are passed through
+// untouched — x/net accepts almost anything there.
+func validateNoProxy(list string) error {
+	for _, entry := range strings.Split(list, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || entry == "*" {
+			continue
+		}
+		if strings.Contains(entry, "/") {
+			if _, _, err := net.ParseCIDR(entry); err != nil {
+				return fmt.Errorf("entry %q: invalid CIDR", entry)
+			}
+			continue
+		}
+		host := entry
+		if h, _, err := net.SplitHostPort(entry); err == nil {
+			host = h
+		}
+		if looksLikeIP(host) && net.ParseIP(host) == nil {
+			return fmt.Errorf("entry %q: invalid IP address", entry)
+		}
+	}
+	return nil
+}
+
+// looksLikeIP reports whether s consists only of digits, dots and colons —
+// i.e. was meant to be an IP address rather than a hostname.
+func looksLikeIP(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && r != '.' && r != ':' {
+			return false
+		}
+	}
+	return true
+}
+
+// maskProxyURL renders a proxy URL for logging, hiding credentials.
+func maskProxyURL(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	proxyURL, err := parseProxyURL(addr)
+	if err != nil || proxyURL == nil {
+		return redactAddr(addr)
+	}
+	if proxyURL.User != nil {
+		proxyURL.User = nil
+		masked := proxyURL.String()
+		if i := strings.Index(masked, "://"); i >= 0 {
+			masked = masked[:i+3] + "***@" + masked[i+3:]
+		}
+		return masked
+	}
+	return proxyURL.String()
+}
+
+// redactAddr strips any userinfo from a possibly-malformed address, for use
+// in error messages and logs where the address cannot be parsed.
+func redactAddr(addr string) string {
+	at := strings.LastIndex(addr, "@")
+	if at < 0 {
+		return addr
+	}
+	start := 0
+	if i := strings.Index(addr, "://"); i >= 0 {
+		start = i + 3
+	}
+	if at < start {
+		return addr
+	}
+	return addr[:start] + "***" + addr[at:]
+}

--- a/infra/httpproxy/filewatch.go
+++ b/infra/httpproxy/filewatch.go
@@ -1,0 +1,178 @@
+package httpproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"go.yaml.in/yaml/v3"
+)
+
+// fileConfig distinguishes keys absent from the file (fall back to the
+// process environment) from keys explicitly set to an empty value (disable
+// the proxy for that class of requests).
+type fileConfig struct {
+	HTTPProxy  *string `yaml:"http_proxy"`
+	HTTPSProxy *string `yaml:"https_proxy"`
+	NoProxy    *string `yaml:"no_proxy"`
+}
+
+// WatchFile applies the settings file at path and keeps watching it for
+// changes until ctx is done; run it in its own goroutine — setup failures
+// are logged before being returned, so a fire-and-forget
+// `go mgr.WatchFile(...)` never fails silently. An empty path disables
+// watching and keeps the environment-based settings.
+//
+// The file is YAML (JSON is accepted too):
+//
+//	http_proxy: "http://user:pass@10.0.1.1:3128"
+//	https_proxy: "http://10.0.1.1:3128"
+//	no_proxy: "localhost,127.0.0.1,.svc,10.0.0.0/8"
+//
+// A missing file, or a key missing from it, falls back to the corresponding
+// environment variable; deleting the file reverts to environment settings.
+// Unknown keys, files that fail to parse and settings that fail validation
+// are logged and ignored, keeping the last good settings.
+//
+// The watch is placed on the parent directory and any event in it triggers a
+// debounced reload (unchanged settings are a no-op), so rename-replace
+// updates (mv tmp file) and even
+// replacement of the directory itself are all picked up.
+func (m *Manager) WatchFile(ctx context.Context, path string) error {
+	err := m.watchFile(ctx, path)
+	if err != nil {
+		m.log.Error("httpproxy: settings file watch failed; hot reload disabled",
+			"file", path, "error", err)
+	}
+	return err
+}
+
+func (m *Manager) watchFile(ctx context.Context, path string) error {
+	if path == "" {
+		m.log.Info("httpproxy: no settings file configured; using environment settings")
+		return nil
+	}
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("httpproxy: resolve %q: %w", path, err)
+	}
+	dir := filepath.Dir(path)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("httpproxy: start watcher: %w", err)
+	}
+	defer watcher.Close()
+	if err = watcher.Add(dir); err != nil {
+		return fmt.Errorf("httpproxy: watch %q: %w", dir, err)
+	}
+	m.log.Info("httpproxy: watching settings file", "file", path)
+	// Log each distinct problem once, not on every event: repeated logging
+	// would spam on a persistently broken file, and if the service logs
+	// into the watched directory it would even re-trigger itself.
+	lastErr := ""
+	apply := func() {
+		err := m.applyFile(path)
+		switch {
+		case err == nil:
+			lastErr = ""
+		case err.Error() != lastErr:
+			lastErr = err.Error()
+			m.log.Error("httpproxy: keeping previous settings", "file", path, "error", err)
+		}
+	}
+	apply()
+
+	reload := time.NewTimer(m.debounce)
+	reload.Stop()
+	// dirStale is set when the watched directory itself is removed or
+	// renamed: the OS keeps the watch bound to the old inode (or drops it),
+	// so it must be re-established on the current path.
+	dirStale := false
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// Attribute-only events are noise; worse, reading the file
+			// updates atime on some platforms (macOS kqueue reports it as
+			// Chmod), so reacting to them would re-trigger reload forever.
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
+				continue
+			}
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 && filepath.Clean(event.Name) == dir {
+				dirStale = true
+			}
+			reload.Reset(m.debounce)
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			m.log.Error("httpproxy: watch error", "file", path, "error", err)
+		case <-reload.C:
+			apply()
+			if dirStale || !slices.Contains(watcher.WatchList(), dir) {
+				_ = watcher.Remove(dir)
+				if err = watcher.Add(dir); err != nil {
+					m.log.Error("httpproxy: re-watch failed", "dir", dir, "error", err)
+					reload.Reset(time.Second)
+				} else {
+					dirStale = false
+					// The file may have changed before the watch was
+					// re-established; confirm once more.
+					reload.Reset(time.Second)
+				}
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (m *Manager) applyFile(path string) error {
+	cfg, err := loadFile(path)
+	if err == nil {
+		err = m.Update(cfg)
+	}
+	return err
+}
+
+// loadFile reads the settings file and merges it over the process
+// environment. A missing or empty file yields plain environment settings.
+func loadFile(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return FromEnvironment(), nil
+	}
+	if err != nil {
+		return Config{}, err
+	}
+	var file fileConfig
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	// Reject misspelled keys: a typo like "htttp_proxy" must be an error,
+	// not a silently ignored setting.
+	dec.KnownFields(true)
+	if err = dec.Decode(&file); err != nil && !errors.Is(err, io.EOF) {
+		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	cfg := FromEnvironment()
+	if file.HTTPProxy != nil {
+		cfg.HTTPProxy = *file.HTTPProxy
+	}
+	if file.HTTPSProxy != nil {
+		cfg.HTTPSProxy = *file.HTTPSProxy
+	}
+	if file.NoProxy != nil {
+		cfg.NoProxy = *file.NoProxy
+	}
+	return cfg, nil
+}

--- a/infra/httpproxy/filewatch_test.go
+++ b/infra/httpproxy/filewatch_test.go
@@ -1,0 +1,214 @@
+package httpproxy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		missing bool   // no file on disk at all
+		content string // file body when missing == false
+		env     map[string]string
+		want    Config
+		wantErr bool
+	}{
+		{
+			name:    "file overrides env, absent key falls back, empty key disables",
+			content: "http_proxy: \"http://file-proxy:3128\"\nno_proxy: \"\"\n",
+			env: map[string]string{
+				"HTTPS_PROXY": "http://env-proxy:3128",
+				"NO_PROXY":    "env.host",
+			},
+			want: Config{
+				HTTPProxy:  "http://file-proxy:3128",
+				HTTPSProxy: "http://env-proxy:3128",
+				NoProxy:    "",
+			},
+		},
+		{
+			name:    "json accepted",
+			content: `{"http_proxy":"http://json-proxy:3128"}`,
+			want:    Config{HTTPProxy: "http://json-proxy:3128"},
+		},
+		{
+			name:    "comments allowed",
+			content: "# corp proxy\nhttp_proxy: \"http://p:3128\"\n",
+			want:    Config{HTTPProxy: "http://p:3128"},
+		},
+		{
+			name:    "missing file falls back to environment",
+			missing: true,
+			env:     map[string]string{"HTTP_PROXY": "http://env-proxy:3128"},
+			want:    Config{HTTPProxy: "http://env-proxy:3128"},
+		},
+		{
+			name:    "empty file falls back to environment",
+			content: "",
+			env:     map[string]string{"HTTP_PROXY": "http://env-proxy:3128"},
+			want:    Config{HTTPProxy: "http://env-proxy:3128"},
+		},
+		{
+			name:    "misspelled key rejected",
+			content: "htttp_proxy: \"http://p:3128\"\n",
+			wantErr: true,
+		},
+		{
+			name:    "malformed yaml rejected",
+			content: "http_proxy: [broken\n",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearProxyEnv(t)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			path := filepath.Join(t.TempDir(), "proxy.yml")
+			if !tt.missing {
+				writeFile(t, path, tt.content)
+			}
+			got, err := loadFile(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("loadFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("loadFile() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWatchFileReloads(t *testing.T) {
+	clearProxyEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "proxy.yml")
+	writeFile(t, path, "http_proxy: \"http://proxy-a:3128\"\n")
+
+	m := NewManager(WithDebounce(10 * time.Millisecond))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- m.WatchFile(ctx, path) }()
+
+	waitFor(t, "initial load", func() bool {
+		return m.Current().HTTPProxy == "http://proxy-a:3128"
+	})
+
+	// In-place edit.
+	writeFile(t, path, "http_proxy: \"http://proxy-b:3128\"\n")
+	waitFor(t, "reload after edit", func() bool {
+		return m.Current().HTTPProxy == "http://proxy-b:3128"
+	})
+
+	// Atomic rename-replace, the way ConfigMaps and editors update files.
+	tmp := filepath.Join(dir, "proxy.yml.tmp")
+	writeFile(t, tmp, "http_proxy: \"http://proxy-c:3128\"\n")
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "reload after rename-replace", func() bool {
+		return m.Current().HTTPProxy == "http://proxy-c:3128"
+	})
+
+	// Malformed file keeps the last good settings.
+	writeFile(t, path, "http_proxy: [broken\n")
+	time.Sleep(100 * time.Millisecond)
+	if got := m.Current().HTTPProxy; got != "http://proxy-c:3128" {
+		t.Fatalf("malformed file replaced settings: %q", got)
+	}
+
+	// Deleting the file reverts to environment settings.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "revert to environment after delete", func() bool {
+		return m.Current().HTTPProxy == ""
+	})
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WatchFile returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchFile did not stop on context cancel")
+	}
+}
+
+func TestWatchFileSurvivesDirectoryReplace(t *testing.T) {
+	clearProxyEnv(t)
+	root := t.TempDir()
+	dir := filepath.Join(root, "conf")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "proxy.yml")
+	writeFile(t, path, "http_proxy: \"http://proxy-a:3128\"\n")
+
+	m := NewManager(WithDebounce(10 * time.Millisecond))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.WatchFile(ctx, path)
+
+	waitFor(t, "initial load", func() bool {
+		return m.Current().HTTPProxy == "http://proxy-a:3128"
+	})
+
+	// Replace the whole directory, the way a config dir may be redeployed.
+	if err := os.Rename(dir, dir+".bak"); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "revert to environment after dir rename", func() bool {
+		return m.Current().HTTPProxy == ""
+	})
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, path, "http_proxy: \"http://proxy-b:3128\"\n")
+	waitFor(t, "reload from recreated directory", func() bool {
+		return m.Current().HTTPProxy == "http://proxy-b:3128"
+	})
+}
+
+func TestWatchFileEmptyPathIsNoop(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+	if err := m.WatchFile(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWatchFileMissingDirFails(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+	err := m.WatchFile(context.Background(), filepath.Join(t.TempDir(), "nosuchdir", "proxy.yml"))
+	if err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+}

--- a/infra/httpproxy/go.mod
+++ b/infra/httpproxy/go.mod
@@ -1,0 +1,14 @@
+module github.com/webitel/webitel-go-kit/infra/httpproxy
+
+go 1.24.0
+
+require (
+	github.com/fsnotify/fsnotify v1.9.0
+	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/net v0.49.0
+)
+
+require (
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+)

--- a/infra/httpproxy/go.sum
+++ b/infra/httpproxy/go.sum
@@ -1,0 +1,12 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
+golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/infra/httpproxy/manager.go
+++ b/infra/httpproxy/manager.go
@@ -1,0 +1,170 @@
+// Package httpproxy provides hot-reloadable forward-proxy settings
+// (http_proxy / https_proxy / no_proxy) for outbound HTTP clients.
+//
+// A Manager holds the current settings in an atomic snapshot and exposes a
+// Proxy method assignable to http.Transport.Proxy. The transport consults
+// that function on every request, so settings changed at runtime — via
+// Update or a watched config file (WatchFile) — take effect immediately,
+// without rebuilding clients or restarting the service. After every applied
+// change the Manager closes idle connections on all registered transports,
+// so pooled keep-alive connections do not keep using the previous route.
+//
+// Typical wiring at service startup:
+//
+//	mgr := httpproxy.NewManager(httpproxy.WithLogger(log))
+//	if err := mgr.HookDefaultTransport(); err != nil { ... }
+//	go mgr.WatchFile(ctx, os.Getenv("PROXY_CONFIG_FILE"))
+//
+// and for custom transports:
+//
+//	t := mgr.Transport()            // clone of http.DefaultTransport
+//	t2 := mgr.WrapTransport(custom) // caller-built *http.Transport
+package httpproxy
+
+import (
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const defaultDebounce = 250 * time.Millisecond
+
+// IdleCloser is the subset of *http.Transport used to invalidate pooled
+// connections after a settings change.
+type IdleCloser interface {
+	CloseIdleConnections()
+}
+
+// Manager holds the current proxy settings and the set of transports that
+// depend on them. The zero value is not usable; use NewManager.
+type Manager struct {
+	log      *slog.Logger
+	debounce time.Duration
+
+	// updateMu serializes Update calls; snap stays atomic for lock-free reads.
+	updateMu sync.Mutex
+	snap     atomic.Pointer[snapshot]
+
+	mu         sync.Mutex
+	transports []IdleCloser
+
+	// shared is the lazily-built transport behind Client, so per-request
+	// Client calls reuse one connection pool and one registration.
+	sharedOnce sync.Once
+	shared     *http.Transport
+}
+
+type snapshot struct {
+	cfg   Config
+	proxy func(*url.URL) (*url.URL, error)
+}
+
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithLogger sets the logger used for settings changes and watch errors.
+// Defaults to slog.Default().
+func WithLogger(log *slog.Logger) Option {
+	return func(m *Manager) {
+		if log != nil {
+			m.log = log
+		}
+	}
+}
+
+// WithDebounce sets how long WatchFile coalesces bursts of file events
+// before reloading. Defaults to 250ms.
+func WithDebounce(d time.Duration) Option {
+	return func(m *Manager) {
+		if d > 0 {
+			m.debounce = d
+		}
+	}
+}
+
+// NewManager returns a Manager initialized from the process environment
+// (HTTP_PROXY, HTTPS_PROXY, NO_PROXY).
+func NewManager(opts ...Option) *Manager {
+	m := &Manager{
+		log:      slog.Default(),
+		debounce: defaultDebounce,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	m.snap.Store(newSnapshot(FromEnvironment()))
+	return m
+}
+
+func newSnapshot(c Config) *snapshot {
+	return &snapshot{cfg: c, proxy: c.proxyFunc()}
+}
+
+// Proxy resolves the proxy URL for a single request against the current
+// settings. Assign it to http.Transport.Proxy: because the transport calls
+// it on every request, long-lived clients pick up settings changes without
+// being rebuilt.
+func (m *Manager) Proxy(req *http.Request) (*url.URL, error) {
+	return m.snap.Load().proxy(req.URL)
+}
+
+// Current returns the settings in effect.
+func (m *Manager) Current() Config {
+	return m.snap.Load().cfg
+}
+
+// Update validates the settings and atomically makes them current, then
+// closes idle connections on all registered transports so that new requests
+// re-dial via the new route. On validation error the previous settings stay
+// in effect. Unchanged settings are a no-op.
+func (m *Manager) Update(c Config) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	m.updateMu.Lock()
+	defer m.updateMu.Unlock()
+	prev := m.snap.Load().cfg
+	if prev == c {
+		return nil
+	}
+	m.snap.Store(newSnapshot(c))
+	m.closeIdleConnections()
+	m.log.Info("httpproxy: settings changed",
+		slog.Group("old",
+			"http_proxy", maskProxyURL(prev.HTTPProxy),
+			"https_proxy", maskProxyURL(prev.HTTPSProxy),
+			"no_proxy", prev.NoProxy),
+		slog.Group("new",
+			"http_proxy", maskProxyURL(c.HTTPProxy),
+			"https_proxy", maskProxyURL(c.HTTPSProxy),
+			"no_proxy", c.NoProxy),
+	)
+	return nil
+}
+
+// Register adds a long-lived transport to the set whose idle connections are
+// closed after every settings change. Transports obtained from Transport,
+// WrapTransport and HookDefaultTransport are registered automatically.
+// Do not register short-lived per-request transports: the Manager keeps the
+// reference forever, so they would leak — set Proxy on them directly instead.
+func (m *Manager) Register(t IdleCloser) {
+	if t == nil {
+		return
+	}
+	m.mu.Lock()
+	m.transports = append(m.transports, t)
+	m.mu.Unlock()
+}
+
+func (m *Manager) closeIdleConnections() {
+	m.mu.Lock()
+	transports := slices.Clone(m.transports)
+	m.mu.Unlock()
+	for _, t := range transports {
+		t.CloseIdleConnections()
+	}
+}

--- a/infra/httpproxy/manager_test.go
+++ b/infra/httpproxy/manager_test.go
@@ -1,0 +1,435 @@
+package httpproxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// clearProxyEnv isolates tests from the host's proxy environment.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+		"REQUEST_METHOD",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func mustRequest(t *testing.T, target string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func proxyFor(t *testing.T, m *Manager, target string) *url.URL {
+	t.Helper()
+	proxyURL, err := m.Proxy(mustRequest(t, target))
+	if err != nil {
+		t.Fatalf("Proxy(%s): %v", target, err)
+	}
+	return proxyURL
+}
+
+func TestUpdateSwapsProxyResolution(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+
+	if got := proxyFor(t, m, "http://example.invalid/"); got != nil {
+		t.Fatalf("expected direct connection initially, got %v", got)
+	}
+
+	if err := m.Update(Config{HTTPProxy: "http://proxy-a:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := proxyFor(t, m, "http://example.invalid/"); got == nil || got.Host != "proxy-a:3128" {
+		t.Fatalf("expected proxy-a:3128, got %v", got)
+	}
+
+	if err := m.Update(Config{HTTPProxy: "http://proxy-b:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := proxyFor(t, m, "http://example.invalid/"); got == nil || got.Host != "proxy-b:3128" {
+		t.Fatalf("expected proxy-b:3128, got %v", got)
+	}
+}
+
+func TestProxyResolution(t *testing.T) {
+	noProxyCfg := Config{
+		HTTPProxy: "http://proxy:3128",
+		NoProxy:   "exact.host, .corp.example.com, 10.0.0.0/8",
+	}
+	tests := []struct {
+		name   string
+		cfg    Config
+		target string
+		want   string // resolved proxy URL; "" means direct
+	}{
+		{
+			name:   "empty settings mean direct",
+			cfg:    Config{},
+			target: "http://example.invalid/",
+			want:   "",
+		},
+		{
+			name:   "bare host:port gets http scheme",
+			cfg:    Config{HTTPProxy: "proxy-a:3128"},
+			target: "http://example.invalid/",
+			want:   "http://proxy-a:3128",
+		},
+		{
+			name:   "https requests use https_proxy",
+			cfg:    Config{HTTPProxy: "proxy-a:3128", HTTPSProxy: "https://proxy-b:3129"},
+			target: "https://example.invalid/",
+			want:   "https://proxy-b:3129",
+		},
+		{
+			name:   "http requests ignore https_proxy",
+			cfg:    Config{HTTPSProxy: "https://proxy-b:3129"},
+			target: "http://example.invalid/",
+			want:   "",
+		},
+		{
+			name:   "no_proxy exact host",
+			cfg:    noProxyCfg,
+			target: "http://exact.host/",
+			want:   "",
+		},
+		{
+			name:   "no_proxy domain suffix",
+			cfg:    noProxyCfg,
+			target: "http://svc.corp.example.com/",
+			want:   "",
+		},
+		{
+			name:   "no_proxy CIDR",
+			cfg:    noProxyCfg,
+			target: "http://10.1.2.3/",
+			want:   "",
+		},
+		{
+			name:   "host outside no_proxy is proxied",
+			cfg:    noProxyCfg,
+			target: "http://proxied.invalid/",
+			want:   "http://proxy:3128",
+		},
+		{
+			name:   "suffix does not match unrelated domain",
+			cfg:    noProxyCfg,
+			target: "http://other.example.com:443/",
+			want:   "http://proxy:3128",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearProxyEnv(t)
+			m := NewManager()
+			if err := m.Update(tt.cfg); err != nil {
+				t.Fatal(err)
+			}
+			got := ""
+			if proxyURL := proxyFor(t, m, tt.target); proxyURL != nil {
+				got = proxyURL.String()
+			}
+			if got != tt.want {
+				t.Errorf("Proxy(%s) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateInvalidKeepsPrevious(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+	if err := m.Update(Config{HTTPProxy: "http://good:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Update(Config{HTTPProxy: "http://bad host:3128"}); err == nil {
+		t.Fatal("expected validation error")
+	}
+	if got := m.Current().HTTPProxy; got != "http://good:3128" {
+		t.Fatalf("previous settings lost: %q", got)
+	}
+}
+
+type idleSpy struct{ calls atomic.Int32 }
+
+func (s *idleSpy) CloseIdleConnections() { s.calls.Add(1) }
+
+func TestUpdateClosesIdleConnectionsOnceOnChange(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+	spy := &idleSpy{}
+	m.Register(spy)
+
+	if err := m.Update(Config{HTTPProxy: "http://proxy:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := spy.calls.Load(); got != 1 {
+		t.Fatalf("expected 1 CloseIdleConnections call, got %d", got)
+	}
+	// Unchanged settings must be a no-op.
+	if err := m.Update(Config{HTTPProxy: "http://proxy:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := spy.calls.Load(); got != 1 {
+		t.Fatalf("no-op update closed connections: %d calls", got)
+	}
+}
+
+// startProxy returns an httptest server that acts as a plain-HTTP forward
+// proxy replying with its own id, so the test can tell which proxy served
+// the request.
+func startProxy(t *testing.T, id string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !r.URL.IsAbs() {
+			http.Error(w, "not a proxy request", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.WriteString(w, id)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestLongLivedTransportSeesSwap(t *testing.T) {
+	clearProxyEnv(t)
+	proxyA := startProxy(t, "A")
+	proxyB := startProxy(t, "B")
+
+	m := NewManager()
+	client := m.Client(5 * time.Second)
+
+	fetch := func() string {
+		t.Helper()
+		resp, err := client.Get("http://target.invalid/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(body)
+	}
+
+	if err := m.Update(Config{HTTPProxy: proxyA.URL}); err != nil {
+		t.Fatal(err)
+	}
+	if got := fetch(); got != "A" {
+		t.Fatalf("expected response from proxy A, got %q", got)
+	}
+	// Same client, warm connection pool: the swap must still take effect.
+	if err := m.Update(Config{HTTPProxy: proxyB.URL}); err != nil {
+		t.Fatal(err)
+	}
+	if got := fetch(); got != "B" {
+		t.Fatalf("expected response from proxy B after swap, got %q", got)
+	}
+}
+
+func TestHookDefaultTransport(t *testing.T) {
+	clearProxyEnv(t)
+	def, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("http.DefaultTransport is not *http.Transport")
+	}
+	oldProxy := def.Proxy
+	defer func() {
+		def.Proxy = oldProxy
+		def.CloseIdleConnections()
+	}()
+
+	proxy := startProxy(t, "hooked")
+	m := NewManager()
+	if err := m.HookDefaultTransport(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Update(Config{HTTPProxy: proxy.URL}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Get("http://target.invalid/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "hooked" {
+		t.Fatalf("http.Get bypassed the hooked proxy: %q", body)
+	}
+}
+
+func TestWrapTransportEnablesProxyOnTLSTransport(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+	if err := m.Update(Config{HTTPProxy: "http://proxy:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	custom := m.WrapTransport(&http.Transport{})
+	proxyURL, err := custom.Proxy(mustRequest(t, "http://example.invalid/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxyURL == nil || proxyURL.Host != "proxy:3128" {
+		t.Fatalf("wrapped transport does not resolve proxy: %v", proxyURL)
+	}
+}
+
+func TestMaskProxyURL(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "credentials replaced",
+			addr: "http://user:secret@proxy:3128",
+			want: "http://***@proxy:3128",
+		},
+		{
+			name: "no credentials untouched",
+			addr: "http://proxy:3128",
+			want: "http://proxy:3128",
+		},
+		{
+			name: "empty stays empty",
+			addr: "",
+			want: "",
+		},
+		{
+			name: "unparsable input still redacted",
+			addr: "http://user:secret@bad host:3128",
+			want: "http://***@bad host:3128",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maskProxyURL(tt.addr); got != tt.want {
+				t.Errorf("maskProxyURL(%q) = %q, want %q", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         Config
+		wantErr     bool
+		errContains string // must appear in the error text
+		errOmits    string // must NOT appear in the error text
+	}{
+		{
+			name: "empty config",
+			cfg:  Config{},
+		},
+		{
+			name: "valid urls and no_proxy list",
+			cfg: Config{
+				HTTPProxy:  "http://proxy:3128",
+				HTTPSProxy: "socks5://proxy:1080",
+				NoProxy:    "localhost, .corp.example.com, 10.0.0.0/8, 192.168.1.5, host:8080, *, ::1",
+			},
+		},
+		{
+			name: "bare host:port accepted",
+			cfg:  Config{HTTPProxy: "proxy:3128"},
+		},
+		{
+			name: "bare host accepted",
+			cfg:  Config{HTTPProxy: "proxy"},
+		},
+		{
+			name:    "port without host rejected",
+			cfg:     Config{HTTPProxy: ":3128"},
+			wantErr: true,
+		},
+		{
+			name:    "scheme without host rejected",
+			cfg:     Config{HTTPProxy: "http://"},
+			wantErr: true,
+		},
+		{
+			name:        "error text redacts credentials",
+			cfg:         Config{HTTPSProxy: "http://user:secret@bad host:3128"},
+			wantErr:     true,
+			errContains: "***",
+			errOmits:    "secret",
+		},
+		{
+			name:    "no_proxy invalid CIDR rejected",
+			cfg:     Config{NoProxy: "10.0.0.0/8x"},
+			wantErr: true,
+		},
+		{
+			name:    "no_proxy invalid IP rejected",
+			cfg:     Config{NoProxy: "10.0.0.256"},
+			wantErr: true,
+		},
+		{
+			name:    "no_proxy short CIDR rejected",
+			cfg:     Config{NoProxy: "1.2.3/24"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("Validate() error %q does not contain %q", err, tt.errContains)
+			}
+			if tt.errOmits != "" && strings.Contains(err.Error(), tt.errOmits) {
+				t.Errorf("Validate() error %q leaks %q", err, tt.errOmits)
+			}
+		})
+	}
+}
+
+func TestCGIGuardPreserved(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("REQUEST_METHOD", "GET")
+	m := NewManager()
+	if err := m.Update(Config{HTTPProxy: "http://proxy:3128"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Proxy(mustRequest(t, "http://example.invalid/")); err == nil {
+		t.Fatal("expected httpoxy guard error in CGI environment")
+	}
+}
+
+func TestClientReusesSharedTransport(t *testing.T) {
+	clearProxyEnv(t)
+	m := NewManager()
+	c1, c2 := m.Client(time.Second), m.Client(2*time.Second)
+	if c1.Transport != c2.Transport {
+		t.Fatal("Client calls must share one transport")
+	}
+	m.mu.Lock()
+	registered := len(m.transports)
+	m.mu.Unlock()
+	if registered != 1 {
+		t.Fatalf("expected 1 registered transport, got %d", registered)
+	}
+}

--- a/infra/httpproxy/transport.go
+++ b/infra/httpproxy/transport.go
@@ -1,0 +1,85 @@
+package httpproxy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Transport returns a clone of http.DefaultTransport with Proxy bound to the
+// Manager and registered for idle-connection invalidation. Create it once
+// and share it: every call permanently registers a new clone with its own
+// connection pool, so calling it per request leaks registrations and defeats
+// keep-alive reuse — for a ready-made shared client use Client instead.
+func (m *Manager) Transport() *http.Transport {
+	var t *http.Transport
+	if def, ok := http.DefaultTransport.(*http.Transport); ok {
+		t = def.Clone()
+	} else {
+		// Keep in sync with net/http.DefaultTransport defaults.
+		t = &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+	}
+	t.Proxy = m.Proxy
+	m.Register(t)
+	return t
+}
+
+// WrapTransport binds a caller-built long-lived transport to the Manager:
+// sets its Proxy and registers it for idle-connection invalidation.
+// A nil argument is equivalent to Transport(). Like Transport, it registers
+// the transport for the Manager's lifetime — do not call it per request;
+// for short-lived transports set Proxy to Manager.Proxy directly.
+func (m *Manager) WrapTransport(t *http.Transport) *http.Transport {
+	if t == nil {
+		return m.Transport()
+	}
+	t.Proxy = m.Proxy
+	m.Register(t)
+	return t
+}
+
+// Client returns an *http.Client backed by the Manager's single shared
+// transport, so it is cheap and safe to call anywhere, including per
+// request: all returned clients reuse one connection pool. A zero timeout
+// means no client-level timeout.
+func (m *Manager) Client(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: m.sharedTransport(),
+		Timeout:   timeout,
+	}
+}
+
+func (m *Manager) sharedTransport() *http.Transport {
+	m.sharedOnce.Do(func() {
+		m.shared = m.Transport()
+	})
+	return m.shared
+}
+
+// HookDefaultTransport binds http.DefaultTransport to the Manager, making
+// every default-transport call site (http.Get, http.DefaultClient,
+// zero-value http.Client, SDKs building on the default transport) honor the
+// current settings. Call it once, as early as possible in main(), before any
+// outbound request is made and before any code clones the default transport:
+// mutating the transport is not synchronized with in-flight requests, and
+// clones taken earlier keep the previous Proxy function.
+func (m *Manager) HookDefaultTransport() error {
+	t, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("httpproxy: http.DefaultTransport is %T, not *http.Transport", http.DefaultTransport)
+	}
+	t.Proxy = m.Proxy
+	m.Register(t)
+	return nil
+}


### PR DESCRIPTION
Новий модуль `infra/httpproxy` - динамічна підтримка `http_proxy`/`https_proxy`/`no_proxy` для вихідного HTTP без рестарту сервісу. Налаштування читаються з невеликого YAML-файла, який відстежується через fsnotify, з fallback на стандартні env-змінні. Перший етап задачі, далі модуль підключається до сервісів (storage, chat_manager, flow_manager, portal).

## Зміни
- Додано `Manager` (`manager.go`): поточні налаштування зберігаються в атомарному снапшоті, метод `Proxy` вставляється в `http.Transport.Proxy` і перечитує снапшот на кожен запит, тому довгоживучі клієнти підхоплюють зміни без перебудови. Після кожної застосованої зміни викликається `CloseIdleConnections()` на зареєстрованих транспортах, щоб keep-alive з'єднання не продовжували ходити через старий проксі
- Додано хелпери для інтеграції (`transport.go`): `HookDefaultTransport()` робить динамічними всі виклики через `http.DefaultTransport` (`http.Get`, `http.DefaultClient`, SDK), `Transport()`/`WrapTransport()` для кастомних транспортів, `Client()` повертає клієнт на єдиному спільному транспорті, безпечний навіть при виклику на кожен запит
- Додано відстеження файла (`filewatch.go`): watch на батьківській директорії, тому переживає rename-replace, заміну самої директорії, з debounce подій. Ключ відсутній у файлі - береться з env, порожній ключ - проксі вимкнено, файла немає - чиста env-поведінка. Битий файл або невалідні значення логуються один раз і чинними лишаються останні робочі налаштування. Невідомі ключі (одруківки) відхиляються через `KnownFields`
- Додано конфігурацію та валідацію (`config.go`): семантика повністю відповідає `golang.org/x/net/http/httpproxy` (включно з httpoxy-guard), але валідація суворіша - відхиляються адреси без хоста та биті CIDR/IP у `no_proxy`, які x/net мовчки ігнорує. Креденшели проксі ніколи не потрапляють у логи та тексти помилок
- Додано тести (22 тести, 30 table-driven кейсів, проходять з `-race`): резолюція проксі та `no_proxy`, валідація, маскування креденшелів, merge файла з env, живе перемикання проксі на теплому клієнті, повний цикл fsnotify (редагування, rename-replace, видалення, заміна директорії)
- Додано `README.md` з інструкцією інтеграції та описом формату файла