### PR TITLE
WTEL-10089: Add infra/health shared health-probes module

### DIFF
--- a/infra/health/README.md
+++ b/infra/health/README.md
@@ -1,0 +1,175 @@
+# health
+
+Health probes for a service and its dependencies. One registry runs the checks
+in the background and caches the last result; transports only read that cache
+and never run a check themselves — so the number of readers has no effect on
+the load a dependency sees.
+
+Two transports ship with it: HTTP (`/livez`, `/readyz`, `/healthz`) and systemd
+`sd_notify` (`READY`, `STATUS`, `STOPPING`, `WATCHDOG`). Service discovery takes
+the verdict directly, as a `func() (bool, error)`.
+
+Standard library only. The package reads no environment, files or flags — the
+caller fills `Config`, or takes `DefaultConfig()`.
+
+## How it works
+
+A check is an ordinary `func(context.Context) error`, so an internal check and a
+database ping look the same to the registry. Each registered check gets its own
+goroutine that runs it, records the result, waits one `Interval`, and repeats.
+
+Registration decides what a failure *means*, and it is chosen by which method
+you call rather than by a struct field:
+
+| | meaning | when it fails |
+|---|---|---|
+| `Critical` | a node-local fault — moving traffic to another node genuinely helps | node leaves rotation |
+| `Liveness` | "is this process wedged?" | node leaves rotation, and `/livez` returns 503 |
+| `Informational` | everything else, typically shared infrastructure | `degraded`: visible, but the node **stays** in rotation |
+
+Making shared infrastructure critical is usually wrong: if a shared database is
+critical, losing it takes the whole fleet out of rotation at once, and there is
+nowhere left to send traffic.
+
+Three rules do the rest:
+
+- **One run at a time.** The check runs inline in its own loop, so a check that
+  ignores its context delays only itself. It cannot pile up goroutines draining
+  the very pool it is testing.
+- **Hysteresis.** A check goes bad after `FailThreshold` consecutive failures,
+  and recovers on the first success but never before `MinUnready` — otherwise a
+  flapping dependency keeps the node in rotation for most of its broken life.
+- **Staleness.** A result older than `StaleAfter` reads as `unknown`, not
+  healthy, so a wedged check cannot serve its last good answer forever.
+
+A registry with no checks — or with only informational ones — is **not ready**:
+nothing registered answers "can this node take traffic?", so no verdict has been
+earned.
+
+## Quick start
+
+```go
+h := health.New(health.DefaultConfig(), log)
+
+h.Critical("grpc", func(ctx context.Context) error { return srv.Ping(ctx) })
+h.Informational("postgres", store.Ping)
+
+if err := h.Start(ctx); err != nil {
+    return err
+}
+```
+
+Hand the verdict to service discovery:
+
+```go
+discovery.NewServiceDiscovery(nodeID, url, h.ReadyFunc())
+```
+
+`ReadyFunc` reads the cached snapshot and returns instantly. **When the verdict
+is `false` the error is never nil**, so a caller may use it without a nil check.
+
+Shut down in this order — `Drain()` returns immediately and the `DrainHold` wait
+happens inside `Stop`, so leave at least `DrainHold` of budget in its context:
+
+```go
+h.Drain()          // not ready from here on, one way
+notifier.Stop(ctx) // if the sd_notify transport is used
+h.Stop(ctx)        // waits out the rest of DrainHold, then halts the scheduler
+```
+
+## HTTP
+
+Mount on an existing router, past authorization — probes must answer without a
+token:
+
+```go
+router.Handle("/livez", healthhttp.LivenessHandler(h))
+router.Handle("/readyz", healthhttp.ReadinessHandler(h))
+router.Handle("/healthz", healthhttp.HealthHandler(h))
+```
+
+Or run a listener of your own, for a service with no HTTP server:
+
+```go
+srv := healthhttp.NewServer(h, "127.0.0.1:8081")
+if err := srv.Start(); err != nil {
+    return err
+}
+defer srv.Stop(ctx)
+```
+
+`healthhttp.Handler(h)` serves all three from one mount by routing on the last
+path segment, which works at the root, under a prefix, or at one exact path. The
+three named handlers ignore the path instead, so a single mount cannot be wrong.
+
+| endpoint | 200 | 503 |
+|---|---|---|
+| `/livez` | `alive` | `wedged` — the scheduler stopped turning |
+| `/readyz` | `ready`, `degraded` | `not_ready`, `unknown`, `stopping` |
+| `/healthz` | JSON detail, same codes as `/readyz` | |
+
+Anything other than `GET` or `HEAD` returns 405 with an `Allow` header.
+
+```json
+{
+  "status": "degraded",
+  "checks": [
+    { "name": "grpc",     "group": "critical",      "status": "ok",   "since": "2026-08-12T10:04:11Z" },
+    { "name": "postgres", "group": "informational", "status": "fail", "since": "2026-08-12T10:07:52Z" }
+  ]
+}
+```
+
+**A check's error text never reaches a response body**, on any endpoint. Names
+and states are safe to expose; the text of a database error is not, and it goes
+to the logger instead. `?verbose` upgrades `/livez` and `/readyz` to the same
+JSON, and only on a `Server` whose listener bound to loopback.
+
+## systemd
+
+```go
+n := sdnotify.New(h) // nil when NOTIFY_SOCKET is unset
+if err := n.Start(ctx); err != nil {
+    return err
+}
+```
+
+With no `NOTIFY_SOCKET` the transport does nothing at all, so a dev machine, a
+container and `go test` cost nothing and need no flag.
+
+| message | when |
+|---|---|
+| `READY=1` | once, when every critical check is green |
+| `STATUS=` | on a state change — shows in `systemctl status` |
+| `STOPPING=1` | at the start of shutdown |
+| `WATCHDOG=1` | periodically, at `WATCHDOG_USEC/2` |
+
+`NOTIFY_SOCKET`, `WATCHDOG_USEC` and `WATCHDOG_PID` are systemd's interface, so
+this is the one place the package reads the environment. The watchdog ping is
+deliberately **not** gated on dependencies — only on whether the registry's own
+scheduler is still turning. Gating it on a database would let one outage restart
+the entire fleet at once, and a restart does not fix a database.
+
+Under `Type=notify`, pick `WatchdogSec` against `StaleAfter`, not by intuition:
+one skipped ping already consumes the whole margin, so use at least
+`4 × StaleAfter` (60s at the defaults) and never below `2 × StaleAfter`. Without
+`WithStartTimeout` there is no `READY=1` fallback, so a unit whose critical check
+never goes green stays in `activating` until `TimeoutStartSec`.
+
+## Configuration
+
+```go
+health.Config{
+    Interval:      5 * time.Second,  // how often each check runs
+    Timeout:       2 * time.Second,  // bounds one run; must be below Interval
+    FailThreshold: 3,                // failures in a row before a check is bad
+    MinUnready:    15 * time.Second, // shortest time a check stays bad
+    StaleAfter:    15 * time.Second, // when a result stops counting
+    DrainHold:     10 * time.Second, // how long Stop waits after Drain
+}
+```
+
+Any field left at zero falls back to its `DefaultConfig` value, so a partial
+`Config` is safe. The defaults are a set rather than independent knobs: they are
+tuned against how often service discovery asks for the verdict, and together they
+put a broken node out of rotation in roughly 25 seconds.

--- a/infra/health/check.go
+++ b/infra/health/check.go
@@ -1,0 +1,189 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Names as they appear in logs and in the /healthz body.
+const (
+	NameUnknown       = "unknown"
+	NameOK            = "ok"
+	NameFail          = "fail"
+	NameLiveness      = "liveness"
+	NameCritical      = "critical"
+	NameInformational = "informational"
+	NameNotReady      = "not_ready"
+	NameDegraded      = "degraded"
+	NameReady         = "ready"
+	NameStopping      = "stopping"
+)
+
+// Check is a health check. It must respect ctx: a Check that ignores it delays
+// its own next run.
+type Check func(context.Context) error
+
+// Group is what a check was registered as.
+type Group uint8
+
+const (
+	GroupLiveness      Group = iota // "is this process wedged?"; counts towards readiness
+	GroupCritical                   // node-local failure: takes the node out of rotation
+	GroupInformational              // only degrades; the node stays in rotation
+)
+
+// Indexed by Group.
+var groupNames = [...]string{NameLiveness, NameCritical, NameInformational}
+
+func (g Group) String() string {
+	if int(g) >= len(groupNames) {
+		return NameUnknown
+	}
+
+	return groupNames[g]
+}
+
+func (g Group) countsForReadiness() bool {
+	return g != GroupInformational
+}
+
+// Status is a check's state once hysteresis and staleness are applied.
+type Status uint8
+
+const (
+	StatusUnknown Status = iota // never ran, or older than Config.StaleAfter; never passes
+	StatusOK
+	StatusFail
+)
+
+// Indexed by Status.
+var statusNames = [...]string{NameUnknown, NameOK, NameFail}
+
+func (s Status) String() string {
+	if int(s) >= len(statusNames) {
+		return NameUnknown
+	}
+
+	return statusNames[s]
+}
+
+// State is the registry's verdict over every check, as carried by a Snapshot.
+type State uint8
+
+const (
+	// StateUnknown means no verdict: no checks, or a counting check without a usable result.
+	StateUnknown State = iota
+
+	// StateNotReady means a liveness or critical check is failing.
+	StateNotReady
+
+	// StateDegraded means only informational checks are not OK; the node stays in rotation.
+	StateDegraded
+
+	// StateReady means every check is OK.
+	StateReady
+
+	// StateStopping means Drain or Stop was called. It is one-way.
+	StateStopping
+)
+
+// Indexed by State.
+var stateNames = [...]string{NameUnknown, NameNotReady, NameDegraded, NameReady, NameStopping}
+
+func (s State) String() string {
+	if int(s) >= len(stateNames) {
+		return NameUnknown
+	}
+
+	return stateNames[s]
+}
+
+// Ready is the verdict bool: degraded still counts as ready.
+func (s State) Ready() bool {
+	return s == StateReady || s == StateDegraded
+}
+
+// CheckResult is one check's state when a snapshot was taken. Err is non-nil
+// whenever Status is not StatusOK, and is for logs only — never a response body.
+type CheckResult struct {
+	Name    string
+	Group   Group
+	Status  Status
+	Since   time.Time // when Status last changed
+	LastRun time.Time // when the last run completed
+	Err     error
+}
+
+// checkState is the live state behind a CheckResult, guarded by the registry's mutex.
+type checkState struct {
+	name  string
+	group Group
+	fn    Check
+
+	status  Status
+	since   time.Time
+	lastRun time.Time
+	lastErr error
+	fails   int
+	ran     bool
+}
+
+// record folds one run's outcome in: down after FailThreshold consecutive
+// failures, up on the first success but not before MinUnready.
+func (cs *checkState) record(now time.Time, err error, cfg Config) (Status, bool) {
+	was := cs.status
+	cs.ran = true
+	cs.lastRun = now
+
+	if err != nil {
+		cs.lastErr = err
+		cs.fails++
+		if cs.fails >= cfg.FailThreshold {
+			cs.set(StatusFail, now)
+		}
+	} else {
+		cs.fails = 0
+		// Held in StatusFail by MinUnready keeps the error that justified it.
+		if cs.status != StatusFail || now.Sub(cs.since) >= cfg.MinUnready {
+			cs.set(StatusOK, now)
+			cs.lastErr = nil
+		}
+	}
+
+	return cs.status, cs.status != was
+}
+
+func (cs *checkState) set(status Status, now time.Time) {
+	if cs.status == status {
+		return
+	}
+
+	cs.status = status
+	cs.since = now
+}
+
+// result reads the check's state, applying staleness at read time.
+func (cs *checkState) result(now time.Time, cfg Config) CheckResult {
+	res := CheckResult{
+		Name:    cs.name,
+		Group:   cs.group,
+		Status:  cs.status,
+		Since:   cs.since,
+		LastRun: cs.lastRun,
+		Err:     cs.lastErr,
+	}
+
+	// Forced unknown synthesizes an error: a not-OK result always explains itself.
+	switch {
+	case !cs.ran:
+		res.Status = StatusUnknown
+		res.Err = fmt.Errorf("check %q has not completed a run yet", cs.name)
+	case now.Sub(cs.lastRun) > cfg.StaleAfter:
+		res.Status = StatusUnknown
+		res.Err = fmt.Errorf("check %q is stale: last run %s ago",
+			cs.name, now.Sub(cs.lastRun).Round(time.Millisecond))
+	}
+
+	return res
+}

--- a/infra/health/check.go
+++ b/infra/health/check.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Names as they appear in logs and in the /healthz body.
+// Names used in logs and in the /healthz body.
 const (
 	NameUnknown       = "unknown"
 	NameOK            = "ok"
@@ -20,8 +20,7 @@ const (
 	NameStopping      = "stopping"
 )
 
-// Check is a health check. It must respect ctx: a Check that ignores it delays
-// its own next run.
+// Check is a health check. It must respect ctx.
 type Check func(context.Context) error
 
 // Group is what a check was registered as.
@@ -33,7 +32,6 @@ const (
 	GroupInformational              // only degrades; the node stays in rotation
 )
 
-// Indexed by Group.
 var groupNames = [...]string{NameLiveness, NameCritical, NameInformational}
 
 func (g Group) String() string {
@@ -57,7 +55,6 @@ const (
 	StatusFail
 )
 
-// Indexed by Status.
 var statusNames = [...]string{NameUnknown, NameOK, NameFail}
 
 func (s Status) String() string {
@@ -72,23 +69,13 @@ func (s Status) String() string {
 type State uint8
 
 const (
-	// StateUnknown means no verdict: no checks, or a counting check without a usable result.
-	StateUnknown State = iota
-
-	// StateNotReady means a liveness or critical check is failing.
-	StateNotReady
-
-	// StateDegraded means only informational checks are not OK; the node stays in rotation.
-	StateDegraded
-
-	// StateReady means every check is OK.
-	StateReady
-
-	// StateStopping means Drain or Stop was called. It is one-way.
-	StateStopping
+	StateUnknown  State = iota // no checks, or a counting check without a usable result
+	StateNotReady              // a liveness or critical check is failing
+	StateDegraded              // only informational checks are not OK; stays in rotation
+	StateReady                 // every check is OK
+	StateStopping              // Drain or Stop was called; one-way
 )
 
-// Indexed by State.
 var stateNames = [...]string{NameUnknown, NameNotReady, NameDegraded, NameReady, NameStopping}
 
 func (s State) String() string {
@@ -99,13 +86,13 @@ func (s State) String() string {
 	return stateNames[s]
 }
 
-// Ready is the verdict bool: degraded still counts as ready.
+// Ready reports whether the state serves traffic; degraded still counts.
 func (s State) Ready() bool {
 	return s == StateReady || s == StateDegraded
 }
 
 // CheckResult is one check's state when a snapshot was taken. Err is non-nil
-// whenever Status is not StatusOK, and is for logs only — never a response body.
+// whenever Status is not StatusOK, and is for logs only.
 type CheckResult struct {
 	Name    string
 	Group   Group
@@ -115,7 +102,7 @@ type CheckResult struct {
 	Err     error
 }
 
-// checkState is the live state behind a CheckResult, guarded by the registry's mutex.
+// checkState is guarded by the registry's mutex.
 type checkState struct {
 	name  string
 	group Group
@@ -129,8 +116,7 @@ type checkState struct {
 	ran     bool
 }
 
-// record folds one run's outcome in: down after FailThreshold consecutive
-// failures, up on the first success but not before MinUnready.
+// record folds one run's outcome in, applying hysteresis.
 func (cs *checkState) record(now time.Time, err error, cfg Config) (Status, bool) {
 	was := cs.status
 	cs.ran = true
@@ -144,7 +130,6 @@ func (cs *checkState) record(now time.Time, err error, cfg Config) (Status, bool
 		}
 	} else {
 		cs.fails = 0
-		// Held in StatusFail by MinUnready keeps the error that justified it.
 		if cs.status != StatusFail || now.Sub(cs.since) >= cfg.MinUnready {
 			cs.set(StatusOK, now)
 			cs.lastErr = nil
@@ -174,7 +159,6 @@ func (cs *checkState) result(now time.Time, cfg Config) CheckResult {
 		Err:     cs.lastErr,
 	}
 
-	// Forced unknown synthesizes an error: a not-OK result always explains itself.
 	switch {
 	case !cs.ran:
 		res.Status = StatusUnknown

--- a/infra/health/check_test.go
+++ b/infra/health/check_test.go
@@ -1,0 +1,199 @@
+package health
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+var errBoom = errors.New("boom")
+
+// failTo drives cs to StatusFail and returns the moment it got there.
+func failTo(t *testing.T, cs *checkState, at time.Time, cfg Config) {
+	t.Helper()
+
+	for i := 0; i < cfg.FailThreshold; i++ {
+		cs.record(at, errBoom, cfg)
+	}
+	if cs.status != StatusFail {
+		t.Fatalf("check did not reach %s after %d failures", NameFail, cfg.FailThreshold)
+	}
+}
+
+func TestFirstSuccessIsImmediate(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{}
+
+	status, changed := cs.record(time.Now(), nil, cfg)
+	if status != StatusOK || !changed {
+		t.Fatalf("got %s changed=%v, want %s changed=true", status, changed, NameOK)
+	}
+}
+
+func TestFailThresholdMustBeConsecutive(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{}
+	now := time.Now()
+
+	for i := 1; i < cfg.FailThreshold; i++ {
+		if status, _ := cs.record(now, errBoom, cfg); status == StatusFail {
+			t.Fatalf("flipped to %s after %d failures, want %d", NameFail, i, cfg.FailThreshold)
+		}
+	}
+
+	if status, changed := cs.record(now, errBoom, cfg); status != StatusFail || !changed {
+		t.Fatalf("got %s changed=%v, want %s changed=true", status, changed, NameFail)
+	}
+}
+
+func TestSingleFailureDoesNotUnseatOK(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{}
+	now := time.Now()
+
+	cs.record(now, nil, cfg)
+
+	if status, changed := cs.record(now, errBoom, cfg); status != StatusOK || changed {
+		t.Fatalf("one failure moved the check to %s", status)
+	}
+}
+
+func TestRecoveryWaitsForMinUnready(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{}
+	start := time.Now()
+
+	failTo(t, cs, start, cfg)
+
+	// A success inside the MinUnready window is not enough: an unstable
+	// dependency must not be able to flap the node back into rotation.
+	if status, _ := cs.record(start.Add(cfg.MinUnready-time.Second), nil, cfg); status != StatusFail {
+		t.Fatalf("recovered before MinUnready elapsed, got %s", status)
+	}
+
+	if status, changed := cs.record(start.Add(cfg.MinUnready), nil, cfg); status != StatusOK || !changed {
+		t.Fatalf("got %s changed=%v, want %s changed=true", status, changed, NameOK)
+	}
+}
+
+func TestNotOKAlwaysCarriesAnError(t *testing.T) {
+	// ReadyFunc's hard invariant leans on this one: engine calls err.Error()
+	// unconditionally when the verdict is false, so a not-OK result with a
+	// nil error is a panic waiting to happen.
+	cfg := DefaultConfig()
+	now := time.Now()
+
+	never := &checkState{name: "never-ran"}
+
+	stale := &checkState{name: "stale"}
+	stale.record(now.Add(-cfg.StaleAfter-time.Second), nil, cfg)
+
+	held := &checkState{name: "held-by-min-unready"}
+	failTo(t, held, now, cfg)
+	held.record(now, nil, cfg) // success inside the MinUnready window
+
+	for _, cs := range []*checkState{never, stale, held} {
+		res := cs.result(now, cfg)
+		if res.Status == StatusOK {
+			t.Errorf("%s: got %s, expected a not-OK state", cs.name, res.Status)
+
+			continue
+		}
+		if res.Err == nil {
+			t.Errorf("%s: status %s with nil Err", cs.name, res.Status)
+		}
+	}
+}
+
+func TestFailureCounterResetsOnSuccess(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{}
+	now := time.Now()
+
+	for i := 1; i < cfg.FailThreshold; i++ {
+		cs.record(now, errBoom, cfg)
+	}
+	cs.record(now, nil, cfg)
+
+	if status, _ := cs.record(now, errBoom, cfg); status == StatusFail {
+		t.Fatalf("a success did not reset the consecutive-failure count")
+	}
+}
+
+func TestResultIsUnknownBeforeFirstRun(t *testing.T) {
+	cs := &checkState{name: "db"}
+
+	if got := cs.result(time.Now(), DefaultConfig()).Status; got != StatusUnknown {
+		t.Fatalf("got %s, want %s", got, NameUnknown)
+	}
+}
+
+func TestStaleResultIsUnknownNotHealthy(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{name: "db"}
+	now := time.Now()
+
+	cs.record(now, nil, cfg)
+
+	if got := cs.result(now.Add(cfg.StaleAfter), cfg).Status; got != StatusOK {
+		t.Fatalf("went stale early: got %s, want %s", got, NameOK)
+	}
+
+	stale := cs.result(now.Add(cfg.StaleAfter+time.Second), cfg)
+	if stale.Status != StatusUnknown {
+		t.Fatalf("stale result reported as %s, want %s", stale.Status, NameUnknown)
+	}
+	if stale.Err == nil {
+		t.Fatal("stale result carries no error")
+	}
+}
+
+func TestResultCarriesLastError(t *testing.T) {
+	cfg := DefaultConfig()
+	cs := &checkState{name: "db"}
+	now := time.Now()
+
+	cs.record(now, errBoom, cfg)
+
+	if got := cs.result(now, cfg).Err; !errors.Is(got, errBoom) {
+		t.Fatalf("got %v, want %v", got, errBoom)
+	}
+}
+
+func TestGroupNames(t *testing.T) {
+	for group, want := range map[Group]string{
+		GroupLiveness:      NameLiveness,
+		GroupCritical:      NameCritical,
+		GroupInformational: NameInformational,
+		Group(200):         NameUnknown,
+	} {
+		if got := group.String(); got != want {
+			t.Errorf("Group(%d) = %q, want %q", group, got, want)
+		}
+	}
+}
+
+func TestStatusNames(t *testing.T) {
+	for status, want := range map[Status]string{
+		StatusUnknown: NameUnknown,
+		StatusOK:      NameOK,
+		StatusFail:    NameFail,
+		Status(200):   NameUnknown,
+	} {
+		if got := status.String(); got != want {
+			t.Errorf("Status(%d) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+func TestOnlyInformationalIsExcludedFromReadiness(t *testing.T) {
+	for group, want := range map[Group]bool{
+		GroupLiveness:      true,
+		GroupCritical:      true,
+		GroupInformational: false,
+	} {
+		if got := group.countsForReadiness(); got != want {
+			t.Errorf("%s.countsForReadiness() = %v, want %v", group, got, want)
+		}
+	}
+}

--- a/infra/health/config.go
+++ b/infra/health/config.go
@@ -2,8 +2,7 @@ package health
 
 import "time"
 
-// Config holds the registry's timings. Fields left at zero fall back to
-// DefaultConfig.
+// Config holds the registry's timings. A zero field falls back to DefaultConfig.
 type Config struct {
 	Interval      time.Duration // how often each check runs
 	Timeout       time.Duration // bounds one run; must be smaller than Interval
@@ -13,9 +12,7 @@ type Config struct {
 	DrainHold     time.Duration // how long Stop waits after Drain before letting go
 }
 
-// DefaultConfig returns the WTEL-10088 timings. They are a set, pinned to
-// engine's 7.5s Consul ping — APP_SERVICE_TTL halved twice
-// (engine/pkg/discovery/consul.go:121,157) — not to the 30s TTL itself.
+// DefaultConfig returns a coherent set of timings, tuned together.
 func DefaultConfig() Config {
 	return Config{
 		Interval:      5 * time.Second,

--- a/infra/health/config.go
+++ b/infra/health/config.go
@@ -1,0 +1,53 @@
+package health
+
+import "time"
+
+// Config holds the registry's timings. Fields left at zero fall back to
+// DefaultConfig.
+type Config struct {
+	Interval      time.Duration // how often each check runs
+	Timeout       time.Duration // bounds one run; must be smaller than Interval
+	FailThreshold int           // failures in a row before a check is StatusFail
+	MinUnready    time.Duration // shortest time a check stays StatusFail
+	StaleAfter    time.Duration // when a result stops counting and reads unknown
+	DrainHold     time.Duration // how long Stop waits after Drain before letting go
+}
+
+// DefaultConfig returns the WTEL-10088 timings. They are a set, pinned to
+// engine's 7.5s Consul ping — APP_SERVICE_TTL halved twice
+// (engine/pkg/discovery/consul.go:121,157) — not to the 30s TTL itself.
+func DefaultConfig() Config {
+	return Config{
+		Interval:      5 * time.Second,
+		Timeout:       2 * time.Second,
+		FailThreshold: 3,
+		MinUnready:    15 * time.Second,
+		StaleAfter:    15 * time.Second,
+		DrainHold:     10 * time.Second,
+	}
+}
+
+func (c Config) withDefaults() Config {
+	def := DefaultConfig()
+
+	if c.Interval <= 0 {
+		c.Interval = def.Interval
+	}
+	if c.Timeout <= 0 {
+		c.Timeout = def.Timeout
+	}
+	if c.FailThreshold <= 0 {
+		c.FailThreshold = def.FailThreshold
+	}
+	if c.MinUnready <= 0 {
+		c.MinUnready = def.MinUnready
+	}
+	if c.StaleAfter <= 0 {
+		c.StaleAfter = def.StaleAfter
+	}
+	if c.DrainHold <= 0 {
+		c.DrainHold = def.DrainHold
+	}
+
+	return c
+}

--- a/infra/health/doc.go
+++ b/infra/health/doc.go
@@ -1,11 +1,3 @@
 // Package health runs service health checks in the background and caches the
-// last result. Transports read the cache and never run a check themselves, so
-// the number of readers has no effect on the load a dependency sees.
-//
-//   - health/http — /livez, /readyz, /healthz
-//   - health/sdnotify — systemd READY, STATUS, STOPPING, WATCHDOG
-//
-// Service discovery takes the verdict from [Registry.ReadyFunc]. The package
-// reads no environment, files or flags; callers fill [Config] themselves, or
-// take [DefaultConfig]. Standard library only.
+// last result. Transports read the cache and never run a check themselves.
 package health

--- a/infra/health/doc.go
+++ b/infra/health/doc.go
@@ -1,0 +1,11 @@
+// Package health runs service health checks in the background and caches the
+// last result. Transports read the cache and never run a check themselves, so
+// the number of readers has no effect on the load a dependency sees.
+//
+//   - health/http — /livez, /readyz, /healthz
+//   - health/sdnotify — systemd READY, STATUS, STOPPING, WATCHDOG
+//
+// Service discovery takes the verdict from [Registry.ReadyFunc]. The package
+// reads no environment, files or flags; callers fill [Config] themselves, or
+// take [DefaultConfig]. Standard library only.
+package health

--- a/infra/health/go.mod
+++ b/infra/health/go.mod
@@ -1,0 +1,3 @@
+module github.com/webitel/webitel-go-kit/infra/health
+
+go 1.25.4

--- a/infra/health/http/body.go
+++ b/infra/health/http/body.go
@@ -10,17 +10,13 @@ import (
 	"github.com/webitel/webitel-go-kit/infra/health"
 )
 
-// The /livez one-word bodies. Liveness has its own vocabulary because the state
-// token contradicts the status line: a draining process is stopping, and alive.
+// The /livez bodies; liveness has its own vocabulary.
 const (
-	// NameAlive is the /livez body on 200.
-	NameAlive = "alive"
-
-	// NameWedged is the /livez body on 503.
+	NameAlive  = "alive"
 	NameWedged = "wedged"
 )
 
-// checkJSON is one check on the wire; declaration order is wire order.
+// checkJSON is one check on the wire.
 type checkJSON struct {
 	Name   string `json:"name"`
 	Group  string `json:"group"`
@@ -33,10 +29,8 @@ type bodyJSON struct {
 	Checks []checkJSON `json:"checks"`
 }
 
-// detail is the only place that decides what a health response looks like. The
-// status it reports is always the readiness state, never the /livez verdict.
-//
-// CheckResult.Err is never read here: check.go says it is for logs only.
+// detail is the only place that shapes a health response. CheckResult.Err is
+// never read here: it is for logs only.
 func detail(s health.Snapshot) bodyJSON {
 	out := bodyJSON{
 		Status: s.State.String(),
@@ -46,9 +40,8 @@ func detail(s health.Snapshot) bodyJSON {
 	for _, c := range s.Checks {
 		cj := checkJSON{Name: c.Name, Group: c.Group.String(), Status: c.Status.String()}
 
-		// since tracks the hysteresis status, not the rendered one: a stale
-		// check renders unknown while carrying the time it went ok. It is zero
-		// for the whole cold start and below FailThreshold, and omitted then.
+		// since tracks the hysteresis status, not the rendered one, and is
+		// zero until the first transition.
 		if !c.Since.IsZero() {
 			cj.Since = c.Since.UTC().Format(time.RFC3339)
 		}
@@ -65,8 +58,7 @@ func writeText(w http.ResponseWriter, code int, token string) {
 	_, _ = io.WriteString(w, token+"\n") // net/http drops this for HEAD
 }
 
-// writeJSON marshals before writing: an encoder failing mid-stream would leave
-// a truncated body behind an already-sent status line.
+// writeJSON marshals before writing, so a failure cannot truncate the body.
 func writeJSON(w http.ResponseWriter, code int, s health.Snapshot, log *slog.Logger) {
 	buf, err := json.Marshal(detail(s))
 	if err != nil {

--- a/infra/health/http/body.go
+++ b/infra/health/http/body.go
@@ -1,0 +1,82 @@
+package healthhttp
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// The /livez one-word bodies. Liveness has its own vocabulary because the state
+// token contradicts the status line: a draining process is stopping, and alive.
+const (
+	// NameAlive is the /livez body on 200.
+	NameAlive = "alive"
+
+	// NameWedged is the /livez body on 503.
+	NameWedged = "wedged"
+)
+
+// checkJSON is one check on the wire; declaration order is wire order.
+type checkJSON struct {
+	Name   string `json:"name"`
+	Group  string `json:"group"`
+	Status string `json:"status"`
+	Since  string `json:"since,omitempty"`
+}
+
+type bodyJSON struct {
+	Status string      `json:"status"`
+	Checks []checkJSON `json:"checks"`
+}
+
+// detail is the only place that decides what a health response looks like. The
+// status it reports is always the readiness state, never the /livez verdict.
+//
+// CheckResult.Err is never read here: check.go says it is for logs only.
+func detail(s health.Snapshot) bodyJSON {
+	out := bodyJSON{
+		Status: s.State.String(),
+		Checks: make([]checkJSON, 0, len(s.Checks)), // never nil: encodes as [], not null
+	}
+
+	for _, c := range s.Checks {
+		cj := checkJSON{Name: c.Name, Group: c.Group.String(), Status: c.Status.String()}
+
+		// since tracks the hysteresis status, not the rendered one: a stale
+		// check renders unknown while carrying the time it went ok. It is zero
+		// for the whole cold start and below FailThreshold, and omitted then.
+		if !c.Since.IsZero() {
+			cj.Since = c.Since.UTC().Format(time.RFC3339)
+		}
+
+		out.Checks = append(out.Checks, cj)
+	}
+
+	return out
+}
+
+func writeText(w http.ResponseWriter, code int, token string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(code)
+	_, _ = io.WriteString(w, token+"\n") // net/http drops this for HEAD
+}
+
+// writeJSON marshals before writing: an encoder failing mid-stream would leave
+// a truncated body behind an already-sent status line.
+func writeJSON(w http.ResponseWriter, code int, s health.Snapshot, log *slog.Logger) {
+	buf, err := json.Marshal(detail(s))
+	if err != nil {
+		log.Error("health/http: encoding the body failed", "err", err)
+		http.Error(w, "encoding failed", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	_, _ = w.Write(buf)
+}

--- a/infra/health/http/body_test.go
+++ b/infra/health/http/body_test.go
@@ -1,0 +1,206 @@
+package healthhttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// sentinel is a string that could not occur by accident, standing in for the
+// kind of connection error that must never reach a response body.
+const sentinel = "dial tcp 10.0.0.5:5432: connect: connection refused / zzz-sentinel-9c1f"
+
+func rfc3339(t *testing.T, s string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", s, err)
+	}
+
+	return ts
+}
+
+func TestHealthzGolden(t *testing.T) {
+	// Snapshots are hand-built so the timestamps are fixed and the bytes are
+	// golden. Compare strings, not decoded maps: field order and omitempty are
+	// the contract.
+	for _, tt := range []struct {
+		name string
+		snap health.Snapshot
+		want string
+	}{
+		{
+			name: "D1 example",
+			snap: health.Snapshot{
+				State: health.StateDegraded,
+				Checks: []health.CheckResult{
+					{Name: "grpc", Group: health.GroupCritical, Status: health.StatusOK,
+						Since: rfc3339(t, "2026-08-08T07:04:11Z")},
+					{Name: "postgres", Group: health.GroupInformational, Status: health.StatusFail,
+						Since: rfc3339(t, "2026-08-08T07:07:52Z")},
+				},
+			},
+			want: `{"status":"degraded","checks":[{"name":"grpc","group":"critical","status":"ok","since":"2026-08-08T07:04:11Z"},{"name":"postgres","group":"informational","status":"fail","since":"2026-08-08T07:07:52Z"}]}`,
+		},
+		{
+			name: "cold start, never run",
+			snap: health.Snapshot{
+				State:  health.StateUnknown,
+				Checks: []health.CheckResult{{Name: "grpc", Group: health.GroupCritical, Status: health.StatusUnknown}},
+			},
+			want: `{"status":"unknown","checks":[{"name":"grpc","group":"critical","status":"unknown"}]}`,
+		},
+		{
+			name: "empty registry",
+			snap: health.Snapshot{State: health.StateUnknown},
+			want: `{"status":"unknown","checks":[]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, err := json.Marshal(detail(tt.snap))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if got := string(buf); got != tt.want {
+				t.Fatalf("body = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHealthzEmptyChecks(t *testing.T) {
+	// An empty registry is a real production state: engine's first moments.
+	body := get(Handler(newTestRegistry(t, fastConfig())), "/healthz").Body.String()
+
+	if !strings.Contains(body, `"checks":[]`) {
+		t.Fatalf("body = %s, want an empty checks array", body)
+	}
+	if strings.Contains(body, `"checks":null`) {
+		t.Fatalf("body = %s, want [] rather than null", body)
+	}
+}
+
+func TestSinceOmitted(t *testing.T) {
+	zero := detail(health.Snapshot{Checks: []health.CheckResult{{Name: "grpc"}}})
+	if zero.Checks[0].Since != "" {
+		t.Fatalf("since = %q, want it omitted for a zero timestamp", zero.Checks[0].Since)
+	}
+
+	buf, err := json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(buf), "since") {
+		t.Fatalf("body = %s, want no since key at all", buf)
+	}
+
+	// Nanoseconds and a non-UTC zone both have to be normalised away.
+	local := time.Date(2026, 8, 8, 10, 4, 11, 123456789, time.FixedZone("EEST", 3*60*60))
+	set := detail(health.Snapshot{Checks: []health.CheckResult{{Name: "grpc", Since: local}}})
+	if got := set.Checks[0].Since; got != "2026-08-08T07:04:11Z" {
+		t.Fatalf("since = %q, want 2026-08-08T07:04:11Z", got)
+	}
+}
+
+func TestHealthzSorted(t *testing.T) {
+	// D1 locks a byte-stable, name-sorted array. detail() preserves input
+	// order, so this drives a real registry: it exists so a future core change
+	// cannot silently break the contract at the transport boundary.
+	reg := newTestRegistry(t, fastConfig())
+	for _, name := range []string{"zulu", "alpha", "mike"} {
+		reg.Critical(name, func(context.Context) error { return nil })
+	}
+	waitState(t, reg, health.StateReady)
+
+	var body bodyJSON
+	raw := get(Handler(reg), "/healthz").Body.Bytes()
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("body %s does not parse: %v", raw, err)
+	}
+
+	for i, want := range []string{"alpha", "mike", "zulu"} {
+		if body.Checks[i].Name != want {
+			t.Fatalf("checks[%d] = %q, want %q", i, body.Checks[i].Name, want)
+		}
+	}
+}
+
+// failingRegistry has one check per group, all failing with the sentinel.
+func failingRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	fail := func(context.Context) error { return errors.New(sentinel) }
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Liveness("live", fail)
+	reg.Critical("db", fail)
+	reg.Informational("s3", fail)
+	waitState(t, reg, health.StateNotReady)
+
+	return reg
+}
+
+func singleEndpointHandler(t *testing.T, r *health.Registry, ep string) http.Handler {
+	t.Helper()
+
+	if ep == epLivez {
+		return LivenessHandler(r)
+	}
+	if ep == epReadyz {
+		return ReadinessHandler(r)
+	}
+
+	return HealthHandler(r)
+}
+
+func assertNoSentinel(t *testing.T, where, body string, header http.Header) {
+	t.Helper()
+
+	if strings.Contains(body, sentinel) {
+		t.Fatalf("%s: the body leaks a check error: %q", where, body)
+	}
+	for key, values := range header {
+		for _, value := range values {
+			if strings.Contains(value, sentinel) {
+				t.Fatalf("%s: header %s leaks a check error: %q", where, key, value)
+			}
+		}
+	}
+}
+
+func TestNoErrorTextLeaks(t *testing.T) {
+	// The property this whole phase exists for, over the cross-product of
+	// endpoint x mode x constructor.
+	reg := failingRegistry(t)
+
+	// Without this the whole test could pass vacuously on a healthy registry.
+	for _, c := range reg.Snapshot().Checks {
+		if c.Status != health.StatusFail {
+			t.Fatalf("check %q is %s, want %s", c.Name, c.Status, health.NameFail)
+		}
+	}
+
+	srv := startServer(t, reg)
+
+	for _, ep := range []string{epLivez, epReadyz, epHealthz} {
+		for _, query := range []string{"", "?verbose"} {
+			target := "/" + ep + query
+
+			rec := get(Handler(reg), target)
+			assertNoSentinel(t, "Handler "+target, rec.Body.String(), rec.Header())
+
+			single := get(singleEndpointHandler(t, reg, ep), target)
+			assertNoSentinel(t, "single-endpoint "+target, single.Body.String(), single.Header())
+
+			_, body, header := fetch(t, "http://"+srv.Addr()+target)
+			assertNoSentinel(t, "Server "+target, body, header)
+		}
+	}
+}

--- a/infra/health/http/doc.go
+++ b/infra/health/http/doc.go
@@ -1,12 +1,3 @@
-// Package healthhttp serves the health registry over HTTP — /livez, /readyz and
-// /healthz — as a handler to mount, or on its own listener.
-//
-// The package name differs from its directory so it does not shadow net/http at
-// import sites. Routing is on the last path segment, so one handler works
-// mounted at the root, under a prefix, or at one exact path; [LivenessHandler],
-// [ReadinessHandler] and [HealthHandler] ignore the path entirely.
-//
-// A check's error text never reaches a response body. ?verbose upgrades /livez
-// and /readyz to the JSON /healthz already serves, and only on a [Server] bound
-// to loopback.
+// Package healthhttp serves the health registry over HTTP: /livez, /readyz and
+// /healthz, as a handler to mount or on its own listener.
 package healthhttp

--- a/infra/health/http/doc.go
+++ b/infra/health/http/doc.go
@@ -1,0 +1,12 @@
+// Package healthhttp serves the health registry over HTTP — /livez, /readyz and
+// /healthz — as a handler to mount, or on its own listener.
+//
+// The package name differs from its directory so it does not shadow net/http at
+// import sites. Routing is on the last path segment, so one handler works
+// mounted at the root, under a prefix, or at one exact path; [LivenessHandler],
+// [ReadinessHandler] and [HealthHandler] ignore the path entirely.
+//
+// A check's error text never reaches a response body. ?verbose upgrades /livez
+// and /readyz to the JSON /healthz already serves, and only on a [Server] bound
+// to loopback.
+package healthhttp

--- a/infra/health/http/handler.go
+++ b/infra/health/http/handler.go
@@ -16,8 +16,7 @@ const (
 	epHealthz = "healthz"
 )
 
-// allowedMethods is the Allow header on a 405. Method gating is ours to do:
-// gorilla/mux forwards every method to the handler it matched.
+// allowedMethods is the Allow header on a 405; gorilla/mux does not gate.
 const allowedMethods = "GET, HEAD"
 
 type handler struct {
@@ -25,7 +24,7 @@ type handler struct {
 	log   *slog.Logger
 	fixed string // one endpoint only; empty means route on the path
 
-	// Atomic: Server.serve grants it, every request reads it.
+	// Atomic: serve grants it, every request reads it.
 	verboseAllowed atomic.Bool
 }
 
@@ -57,7 +56,6 @@ func HealthHandler(r *health.Registry, opts ...Option) http.Handler {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Set once, before any branch, so no response can forget them.
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
@@ -78,8 +76,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Exactly one snapshot: a second one could straddle a state change and pair
-	// a 200 with a not_ready body.
+	// Exactly one snapshot, or a 200 could carry a not_ready body.
 	s := h.reg.Snapshot()
 
 	code, token := readyVerdict(s)
@@ -106,8 +103,7 @@ func readyVerdict(s health.Snapshot) (int, string) {
 }
 
 // liveVerdict is deliberately not derived from s.State: a draining process is
-// stopping but not wedged, and an empty registry is unknown but alive. A
-// liveness check at StatusUnknown is not-ready either, and still not wedged.
+// stopping but not wedged, and an empty registry is unknown but alive.
 func liveVerdict(s health.Snapshot) (int, string) {
 	wedged := !s.SchedulerAlive
 	for _, c := range s.Checks {

--- a/infra/health/http/handler.go
+++ b/infra/health/http/handler.go
@@ -1,0 +1,122 @@
+package healthhttp
+
+import (
+	"log/slog"
+	"net/http"
+	"path"
+	"sync/atomic"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// The endpoints, matched against the last path segment.
+const (
+	epLivez   = "livez"
+	epReadyz  = "readyz"
+	epHealthz = "healthz"
+)
+
+// allowedMethods is the Allow header on a 405. Method gating is ours to do:
+// gorilla/mux forwards every method to the handler it matched.
+const allowedMethods = "GET, HEAD"
+
+type handler struct {
+	reg   *health.Registry
+	log   *slog.Logger
+	fixed string // one endpoint only; empty means route on the path
+
+	// Atomic: Server.serve grants it, every request reads it.
+	verboseAllowed atomic.Bool
+}
+
+func newHandler(reg *health.Registry, o options, verboseAllowed bool, fixed string) *handler {
+	h := &handler{reg: reg, log: o.log, fixed: fixed}
+	h.verboseAllowed.Store(verboseAllowed)
+
+	return h
+}
+
+// Handler serves /livez, /readyz and /healthz, routed on the last path segment.
+func Handler(r *health.Registry, opts ...Option) http.Handler {
+	return newHandler(r, newOptions(opts), false, "")
+}
+
+// LivenessHandler serves /livez at whatever path it is mounted on.
+func LivenessHandler(r *health.Registry, opts ...Option) http.Handler {
+	return newHandler(r, newOptions(opts), false, epLivez)
+}
+
+// ReadinessHandler serves /readyz at whatever path it is mounted on.
+func ReadinessHandler(r *health.Registry, opts ...Option) http.Handler {
+	return newHandler(r, newOptions(opts), false, epReadyz)
+}
+
+// HealthHandler serves /healthz at whatever path it is mounted on.
+func HealthHandler(r *health.Registry, opts ...Option) http.Handler {
+	return newHandler(r, newOptions(opts), false, epHealthz)
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Set once, before any branch, so no response can forget them.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", allowedMethods)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	ep := h.fixed
+	if ep == "" {
+		ep = path.Base(r.URL.Path)
+	}
+	if ep != epLivez && ep != epReadyz && ep != epHealthz {
+		http.NotFound(w, r)
+
+		return
+	}
+
+	// Exactly one snapshot: a second one could straddle a state change and pair
+	// a 200 with a not_ready body.
+	s := h.reg.Snapshot()
+
+	code, token := readyVerdict(s)
+	if ep == epLivez {
+		code, token = liveVerdict(s)
+	}
+
+	if ep == epHealthz || (h.verboseAllowed.Load() && r.URL.Query().Has("verbose")) {
+		writeJSON(w, code, s, h.log)
+
+		return
+	}
+
+	writeText(w, code, token)
+}
+
+func readyVerdict(s health.Snapshot) (int, string) {
+	code := http.StatusServiceUnavailable
+	if s.State.Ready() {
+		code = http.StatusOK
+	}
+
+	return code, s.State.String()
+}
+
+// liveVerdict is deliberately not derived from s.State: a draining process is
+// stopping but not wedged, and an empty registry is unknown but alive. A
+// liveness check at StatusUnknown is not-ready either, and still not wedged.
+func liveVerdict(s health.Snapshot) (int, string) {
+	wedged := !s.SchedulerAlive
+	for _, c := range s.Checks {
+		wedged = wedged || (c.Group == health.GroupLiveness && c.Status == health.StatusFail)
+	}
+
+	if wedged {
+		return http.StatusServiceUnavailable, NameWedged
+	}
+
+	return http.StatusOK, NameAlive
+}

--- a/infra/health/http/handler_test.go
+++ b/infra/health/http/handler_test.go
@@ -1,0 +1,651 @@
+package healthhttp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+const (
+	textCT = "text/plain; charset=utf-8"
+	jsonCT = "application/json; charset=utf-8"
+)
+
+// fastConfig is a starting point for tests that just need a registry which
+// settles quickly. Tests with their own timing requirements override it.
+func fastConfig() health.Config {
+	return health.Config{
+		Interval:      10 * time.Millisecond,
+		Timeout:       5 * time.Millisecond,
+		FailThreshold: 1,
+		MinUnready:    time.Millisecond,
+		StaleAfter:    500 * time.Millisecond,
+		DrainHold:     time.Millisecond,
+	}
+}
+
+func stopAtCleanup(t *testing.T, reg *health.Registry) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		if err := reg.Stop(ctx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+}
+
+// newTestRegistry returns a started registry, stopped again at cleanup. The
+// config is a parameter because the /livez tests need opposite timings.
+func newTestRegistry(t *testing.T, cfg health.Config) *health.Registry {
+	t.Helper()
+
+	reg := health.New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	stopAtCleanup(t, reg)
+
+	return reg
+}
+
+// waitState polls until the registry reports want. Never sleep a fixed
+// duration waiting for a state: -race -count=3 turns that into a flake.
+func waitState(t *testing.T, reg *health.Registry, want health.State) {
+	t.Helper()
+
+	var got health.State
+	for range 2000 {
+		got = reg.Snapshot().State
+		if got == want {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("state = %s, want %s", got, want)
+}
+
+// waitFor polls cond for up to two seconds.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	for range 2000 {
+		if cond() {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// get drives a handler through a recorder. HEAD bodies need a real server; see
+// TestHeadNoBody.
+func get(h http.Handler, target string) *httptest.ResponseRecorder {
+	return do(h, http.MethodGet, target)
+}
+
+func do(h http.Handler, method, target string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, target, nil))
+
+	return rec
+}
+
+func assertResponse(t *testing.T, rec *httptest.ResponseRecorder, code int, body, contentType string) {
+	t.Helper()
+
+	if rec.Code != code {
+		t.Fatalf("status = %d, want %d", rec.Code, code)
+	}
+	if got := rec.Body.String(); got != body {
+		t.Fatalf("body = %q, want %q", got, body)
+	}
+	if got := rec.Header().Get("Content-Type"); got != contentType {
+		t.Fatalf("Content-Type = %q, want %q", got, contentType)
+	}
+}
+
+func failing(name string) health.Check {
+	return func(context.Context) error { return errors.New(name + " is down") }
+}
+
+func passing(context.Context) error { return nil }
+
+// emptyRegistry has no checks at all: unknown for readiness, alive for liveness.
+func emptyRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	return newTestRegistry(t, fastConfig())
+}
+
+// okRegistry is a registry with one passing critical check, settled at ready.
+func okRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	return reg
+}
+
+// notReadyRegistry has a failing critical check.
+func notReadyRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", failing("db"))
+	waitState(t, reg, health.StateNotReady)
+
+	return reg
+}
+
+// degradedRegistry has only an informational check failing.
+func degradedRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	reg.Informational("s3", failing("s3"))
+	waitState(t, reg, health.StateDegraded)
+
+	return reg
+}
+
+// drainingRegistry is ready, then drained: stopping, and still not wedged.
+func drainingRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	reg := okRegistry(t)
+	reg.Drain()
+	waitState(t, reg, health.StateStopping)
+
+	return reg
+}
+
+// wedgedRegistry has a failing liveness check, past its threshold.
+func wedgedRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	// FailThreshold 1: one run settles the check at StatusFail.
+	reg := newTestRegistry(t, fastConfig())
+	reg.Liveness("wedge", failing("the event loop"))
+	waitState(t, reg, health.StateNotReady)
+
+	return reg
+}
+
+func TestRouting(t *testing.T) {
+	h := Handler(okRegistry(t))
+
+	root := http.NewServeMux()
+	root.Handle("/", h)
+
+	exact := http.NewServeMux() // engine's style: one endpoint, one exact path
+	exact.Handle("/readyz", h)
+
+	prefix := http.NewServeMux()
+	prefix.Handle("/health/", h)
+
+	stripped := http.NewServeMux()
+	stripped.Handle("/health/", http.StripPrefix("/health", h))
+
+	// Stands in for gorilla's PathPrefix without adding the dependency: the
+	// path reaches the handler unmodified.
+	forwarded := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+	})
+
+	for _, tt := range []struct {
+		name    string
+		mount   http.Handler
+		targets []string
+	}{
+		{"root", root, []string{"/livez", "/readyz", "/healthz"}},
+		{"exact path", exact, []string{"/readyz"}},
+		{"prefix", prefix, []string{"/health/livez", "/health/readyz", "/health/healthz"}},
+		{"prefix stripped", stripped, []string{"/health/livez", "/health/readyz", "/health/healthz"}},
+		{"prefix forwarded", forwarded, []string{"/health/livez", "/health/readyz", "/health/healthz"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, target := range tt.targets {
+				if rec := get(tt.mount, target); rec.Code != http.StatusOK {
+					t.Fatalf("%s: status = %d, want %d", target, rec.Code, http.StatusOK)
+				}
+			}
+		})
+	}
+}
+
+func TestRoutingUnmatched(t *testing.T) {
+	h := Handler(okRegistry(t))
+
+	for _, tt := range []struct {
+		target string
+		code   int
+	}{
+		{"/", http.StatusNotFound},
+		{"/health/", http.StatusNotFound},
+		{"/foo", http.StatusNotFound},
+		{"/healthz/foo", http.StatusNotFound},
+		{"/READYZ", http.StatusNotFound},
+		{"/healthz%2Ffoo", http.StatusNotFound}, // arrives decoded; Base is foo
+		{"/%68ealthz", http.StatusOK},           // arrives decoded; Base is healthz
+		{"/readyz/", http.StatusOK},             // path.Base eats a trailing slash
+	} {
+		t.Run(tt.target, func(t *testing.T) {
+			if rec := get(h, tt.target); rec.Code != tt.code {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.code)
+			}
+		})
+	}
+}
+
+func TestReadyCode(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		setup func(*testing.T) *health.Registry
+		state health.State
+		code  int
+	}{
+		{"unknown", emptyRegistry, health.StateUnknown, http.StatusServiceUnavailable},
+		{"not_ready", notReadyRegistry, health.StateNotReady, http.StatusServiceUnavailable},
+		{"degraded", degradedRegistry, health.StateDegraded, http.StatusOK},
+		{"ready", okRegistry, health.StateReady, http.StatusOK},
+		{"stopping", drainingRegistry, health.StateStopping, http.StatusServiceUnavailable},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := tt.setup(t)
+			if got := reg.Snapshot().State; got != tt.state {
+				t.Fatalf("state = %s, want %s", got, tt.state)
+			}
+
+			h := Handler(reg)
+			for _, target := range []string{"/readyz", "/healthz"} {
+				if rec := get(h, target); rec.Code != tt.code {
+					t.Fatalf("%s: status = %d, want %d", target, rec.Code, tt.code)
+				}
+			}
+		})
+	}
+}
+
+func TestLivezEmptyIsAlive(t *testing.T) {
+	// The design's inversion: nothing registered means nothing is wedged, even
+	// though readiness has no verdict to give.
+	h := Handler(emptyRegistry(t))
+
+	assertResponse(t, get(h, "/livez"), http.StatusOK, NameAlive+"\n", textCT)
+	assertResponse(t, get(h, "/readyz"), http.StatusServiceUnavailable, health.NameUnknown+"\n", textCT)
+}
+
+func TestLivezDrainingIsAlive(t *testing.T) {
+	// A watchdog must not kill a process that is shutting down politely.
+	h := Handler(drainingRegistry(t))
+
+	assertResponse(t, get(h, "/livez"), http.StatusOK, NameAlive+"\n", textCT)
+	assertResponse(t, get(h, "/readyz"), http.StatusServiceUnavailable, health.NameStopping+"\n", textCT)
+}
+
+func TestLivezLivenessFail(t *testing.T) {
+	// The one case that really is wedged: a liveness check at StatusFail.
+	assertResponse(t, get(Handler(wedgedRegistry(t)), "/livez"),
+		http.StatusServiceUnavailable, NameWedged+"\n", textCT)
+}
+
+func TestLivezUnknownIsAlive(t *testing.T) {
+	// A liveness check below its threshold is unknown: not ready, not wedged.
+	// FailThreshold 100 keeps it there for the whole test instead of a ~20ms
+	// window, and StaleAfter 10s keeps SchedulerAlive true, so the 200 is
+	// decided by the liveness rule rather than by the scheduler.
+	cfg := health.Config{
+		Interval:      50 * time.Millisecond,
+		Timeout:       10 * time.Millisecond,
+		FailThreshold: 100,
+		MinUnready:    time.Millisecond,
+		StaleAfter:    10 * time.Second,
+		DrainHold:     time.Millisecond,
+	}
+
+	reg := newTestRegistry(t, cfg)
+	reg.Liveness("wedge", failing("the event loop"))
+	waitFor(t, "the first run to complete", func() bool {
+		checks := reg.Snapshot().Checks
+
+		return len(checks) == 1 && !checks[0].LastRun.IsZero()
+	})
+
+	if got := reg.Snapshot().Checks[0].Status; got != health.StatusUnknown {
+		t.Fatalf("check status = %s, want %s", got, health.NameUnknown)
+	}
+
+	h := Handler(reg)
+	assertResponse(t, get(h, "/livez"), http.StatusOK, NameAlive+"\n", textCT)
+	assertResponse(t, get(h, "/readyz"), http.StatusServiceUnavailable, health.NameUnknown+"\n", textCT)
+}
+
+func TestLivezSchedulerDead(t *testing.T) {
+	// The opposite timing to TestLivezUnknownIsAlive, which is why
+	// newTestRegistry takes a config: a short StaleAfter lets the scheduler be
+	// observed to stop turning.
+	cfg := fastConfig()
+	cfg.StaleAfter = 50 * time.Millisecond
+
+	reg := newTestRegistry(t, cfg)
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := reg.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	waitFor(t, "the scheduler to go stale", func() bool { return !reg.Snapshot().SchedulerAlive })
+
+	assertResponse(t, get(Handler(reg), "/livez"),
+		http.StatusServiceUnavailable, NameWedged+"\n", textCT)
+}
+
+func TestVerboseStoppingBody(t *testing.T) {
+	// The one-word /livez path never pairs 200 with the token stopping; the
+	// verbose path does, because it renders the whole snapshot and the
+	// snapshot's status is the readiness state, not the liveness verdict.
+	// body.go says the same thing where detail() is defined.
+	srv := startServer(t, drainingRegistry(t))
+
+	code, body, header := fetch(t, "http://"+srv.Addr()+"/livez?verbose")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", code, http.StatusOK)
+	}
+	if got := header.Get("Content-Type"); got != jsonCT {
+		t.Fatalf("Content-Type = %q, want %q", got, jsonCT)
+	}
+	if !strings.HasPrefix(body, `{"status":"`+health.NameStopping+`"`) {
+		t.Fatalf("body = %s, want the snapshot's stopping status", body)
+	}
+}
+
+func TestBodyTokens(t *testing.T) {
+	stateTokens := []string{
+		health.NameUnknown, health.NameNotReady, health.NameDegraded,
+		health.NameReady, health.NameStopping,
+	}
+
+	for _, tt := range []struct {
+		name   string
+		setup  func(*testing.T) *health.Registry
+		livez  string
+		readyz string
+	}{
+		{"alive", okRegistry, NameAlive + "\n", health.NameReady + "\n"},
+		{"wedged", wedgedRegistry, NameWedged + "\n", health.NameNotReady + "\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h := Handler(tt.setup(t))
+
+			livez := get(h, "/livez").Body.String()
+			if livez != tt.livez {
+				t.Fatalf("/livez body = %q, want %q", livez, tt.livez)
+			}
+			if got := get(h, "/readyz").Body.String(); got != tt.readyz {
+				t.Fatalf("/readyz body = %q, want %q", got, tt.readyz)
+			}
+
+			for _, token := range stateTokens {
+				if livez == token+"\n" {
+					t.Fatalf("/livez speaks the state token %q; liveness has its own vocabulary", token)
+				}
+			}
+		})
+	}
+}
+
+func TestResponseHeaders(t *testing.T) {
+	ok, down := okRegistry(t), notReadyRegistry(t)
+
+	for _, tt := range []struct {
+		name        string
+		reg         *health.Registry
+		method      string
+		target      string
+		code        int
+		contentType string
+	}{
+		{"livez 200", ok, http.MethodGet, "/livez", http.StatusOK, textCT},
+		{"readyz 200", ok, http.MethodGet, "/readyz", http.StatusOK, textCT},
+		{"healthz 200", ok, http.MethodGet, "/healthz", http.StatusOK, jsonCT},
+		{"readyz 503", down, http.MethodGet, "/readyz", http.StatusServiceUnavailable, textCT},
+		{"healthz 503", down, http.MethodGet, "/healthz", http.StatusServiceUnavailable, jsonCT},
+		{"404", ok, http.MethodGet, "/nope", http.StatusNotFound, textCT},
+		{"405", ok, http.MethodPost, "/readyz", http.StatusMethodNotAllowed, textCT},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := do(Handler(tt.reg), tt.method, tt.target)
+
+			if rec.Code != tt.code {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.code)
+			}
+			if got := rec.Header().Get("Content-Type"); got != tt.contentType {
+				t.Fatalf("Content-Type = %q, want %q", got, tt.contentType)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+			if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+			}
+		})
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	// engine's gorilla/mux forwards POST /readyz to the handler at 200, so the
+	// method gate is ours to enforce; the router gives us nothing.
+	h := Handler(okRegistry(t))
+
+	for _, method := range []string{
+		http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions,
+	} {
+		for _, target := range []string{"/livez", "/readyz", "/healthz"} {
+			t.Run(method+" "+target, func(t *testing.T) {
+				rec := do(h, method, target)
+
+				if rec.Code != http.StatusMethodNotAllowed {
+					t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+				}
+				if got := rec.Header().Get("Allow"); got != allowedMethods {
+					t.Fatalf("Allow = %q, want %q", got, allowedMethods)
+				}
+			})
+		}
+	}
+}
+
+func TestHeadNoBody(t *testing.T) {
+	// A real server: httptest.NewRecorder does not emulate net/http discarding
+	// a HEAD body, so a recorder-based version of this test asserts nothing.
+	srv := httptest.NewServer(Handler(okRegistry(t)))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL+"/readyz", nil)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HEAD /readyz: %v", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("reading the body: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	if res.ContentLength <= 0 {
+		t.Fatalf("Content-Length = %d, want the length of the body it would have sent", res.ContentLength)
+	}
+	if len(body) != 0 {
+		t.Fatalf("body = %q, want no bytes at all", body)
+	}
+}
+
+func TestVerboseIgnoredOnHandler(t *testing.T) {
+	// A Handler has no address, so it can never satisfy the loopback rule.
+	reg := okRegistry(t)
+	queries := []string{"?verbose", "?verbose=", "?verbose=0", "?verbose=false"}
+
+	for _, ep := range []string{epLivez, epReadyz, epHealthz} {
+		want := get(Handler(reg), "/"+ep).Body.String()
+
+		for _, query := range queries {
+			for _, h := range []http.Handler{Handler(reg), singleEndpointHandler(t, reg, ep)} {
+				if got := get(h, "/"+ep+query).Body.String(); got != want {
+					t.Fatalf("/%s%s body = %q, want %q", ep, query, got, want)
+				}
+			}
+		}
+
+		// /healthz is JSON either way; the other two must stay one-word.
+		if strings.HasPrefix(want, "{") != (ep == epHealthz) {
+			t.Fatalf("/%s body = %q, want the one-word body", ep, want)
+		}
+	}
+}
+
+func TestNilRegistry(t *testing.T) {
+	h := Handler(nil)
+
+	assertResponse(t, get(h, "/livez"), http.StatusServiceUnavailable, NameWedged+"\n", textCT)
+	assertResponse(t, get(h, "/readyz"), http.StatusServiceUnavailable, health.NameUnknown+"\n", textCT)
+	assertResponse(t, get(h, "/healthz"), http.StatusServiceUnavailable,
+		`{"status":"unknown","checks":[]}`, jsonCT)
+}
+
+// assertAgrees pins the /readyz code to ReadyFunc's bool in one state.
+func assertAgrees(t *testing.T, reg *health.Registry, want health.State) {
+	t.Helper()
+
+	if got := reg.Snapshot().State; got != want {
+		t.Fatalf("state = %s, want %s", got, want)
+	}
+
+	ok, err := reg.ReadyFunc()()
+	code := get(Handler(reg), "/readyz").Code
+
+	if ok != (code == http.StatusOK) {
+		t.Fatalf("%s: ReadyFunc = %v but /readyz = %d", want, ok, code)
+	}
+	if !ok && err == nil {
+		t.Fatalf("%s: a false verdict with a nil error would panic engine", want)
+	}
+}
+
+func TestVerdictAgreesWithReadyFunc(t *testing.T) {
+	// The transport must never drift from service discovery. The steps are
+	// ordered: MinUnready gates the way back to ready, and StateStopping is
+	// one-way, so Drain comes last.
+	var dbDown, s3Down atomic.Bool
+
+	reg := health.New(fastConfig(), nil)
+	reg.Critical("db", func(context.Context) error {
+		if dbDown.Load() {
+			return errors.New("db is down")
+		}
+
+		return nil
+	})
+	reg.Informational("s3", func(context.Context) error {
+		if s3Down.Load() {
+			return errors.New("s3 is down")
+		}
+
+		return nil
+	})
+
+	// Cold, before any run: asserted before Start, because the first run lands
+	// within a millisecond of it.
+	assertAgrees(t, reg, health.StateUnknown)
+
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	stopAtCleanup(t, reg)
+
+	waitState(t, reg, health.StateReady)
+	assertAgrees(t, reg, health.StateReady)
+
+	dbDown.Store(true)
+	waitState(t, reg, health.StateNotReady)
+	assertAgrees(t, reg, health.StateNotReady)
+
+	dbDown.Store(false)
+	waitState(t, reg, health.StateReady) // only once MinUnready has elapsed
+	assertAgrees(t, reg, health.StateReady)
+
+	s3Down.Store(true)
+	waitState(t, reg, health.StateDegraded)
+	assertAgrees(t, reg, health.StateDegraded)
+
+	reg.Drain()
+	waitState(t, reg, health.StateStopping)
+	assertAgrees(t, reg, health.StateStopping)
+}
+
+func TestConcurrentScrape(t *testing.T) {
+	// The assertion is that nothing panics and -race stays silent.
+	var dbDown atomic.Bool
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", func(context.Context) error {
+		if dbDown.Load() {
+			return errors.New("db is down")
+		}
+
+		return nil
+	})
+
+	h := Handler(reg)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for range 50 {
+				for _, target := range []string{"/livez", "/readyz", "/healthz"} {
+					get(h, target)
+				}
+			}
+		}()
+	}
+
+	for range 10 {
+		dbDown.Store(!dbDown.Load())
+		time.Sleep(time.Millisecond)
+	}
+	reg.Drain()
+
+	wg.Wait()
+}

--- a/infra/health/http/options.go
+++ b/infra/health/http/options.go
@@ -1,0 +1,32 @@
+package healthhttp
+
+import "log/slog"
+
+// Option configures a handler or a Server.
+type Option func(*options)
+
+type options struct {
+	log *slog.Logger
+}
+
+// WithLogger sets the logger. A nil logger is ignored.
+func WithLogger(log *slog.Logger) Option {
+	return func(o *options) {
+		if log == nil {
+			return
+		}
+
+		o.log = log
+	}
+}
+
+// newOptions applies opts over a discarding logger: a library must not write to
+// stderr uninvited, so the default is never slog.Default.
+func newOptions(opts []Option) options {
+	o := options{log: slog.New(slog.DiscardHandler)}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return o
+}

--- a/infra/health/http/options.go
+++ b/infra/health/http/options.go
@@ -21,7 +21,7 @@ func WithLogger(log *slog.Logger) Option {
 }
 
 // newOptions applies opts over a discarding logger: a library must not write to
-// stderr uninvited, so the default is never slog.Default.
+// stderr uninvited.
 func newOptions(opts []Option) options {
 	o := options{log: slog.New(slog.DiscardHandler)}
 	for _, opt := range opts {

--- a/infra/health/http/race_test.go
+++ b/infra/health/http/race_test.go
@@ -1,0 +1,350 @@
+package healthhttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// Run under -race. Most of these assert only "no race, no panic, no deadlock,
+// no leak" — the detector and the test timeout are the assertions.
+
+func racyConfig() health.Config {
+	return health.Config{
+		Interval:      time.Millisecond,
+		Timeout:       500 * time.Microsecond,
+		FailThreshold: 1,
+		MinUnready:    time.Microsecond,
+		StaleAfter:    50 * time.Millisecond,
+		DrainHold:     time.Millisecond,
+	}
+}
+
+func racyRegistry(t *testing.T) *health.Registry {
+	t.Helper()
+
+	reg := health.New(racyConfig(), nil)
+	reg.Critical("db", func(context.Context) error { return nil })
+	reg.Informational("s3", func(context.Context) error { return nil })
+
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		reg.Stop(ctx)
+	})
+
+	return reg
+}
+
+func settled(t *testing.T, want int) int {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	got := runtime.NumGoroutine()
+	for time.Now().Before(deadline) {
+		got = runtime.NumGoroutine()
+		if got <= want {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	return got
+}
+
+// TestRaceSecondStartIsRefused is the regression test for the shipped data race
+// found in review: a second Start bound another port and rewrote the verbose
+// grant while requests were already in flight on the first listener.
+func TestRaceSecondStartIsRefused(t *testing.T) {
+	reg := racyRegistry(t)
+	srv := NewServer(reg, "127.0.0.1:0")
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop(context.Background()) })
+
+	first := srv.Addr()
+
+	if err := srv.Start(); err == nil {
+		t.Fatal("second Start succeeded; it must be refused, not bind another port")
+	}
+	if got := srv.Addr(); got != first {
+		t.Fatalf("Addr moved from %q to %q after a refused Start", first, got)
+	}
+}
+
+func TestRaceConcurrentStartsBindOnePort(t *testing.T) {
+	reg := racyRegistry(t)
+
+	for round := 0; round < 10; round++ {
+		srv := NewServer(reg, "127.0.0.1:0")
+
+		var mu sync.Mutex
+		var wins int
+
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := srv.Start(); err == nil {
+					mu.Lock()
+					wins++
+					mu.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+
+		if wins != 1 {
+			t.Fatalf("round %d: %d concurrent Starts succeeded, want exactly 1", round, wins)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		srv.Stop(ctx)
+		cancel()
+	}
+}
+
+func TestRaceRequestsWhileStartingAndStopping(t *testing.T) {
+	// Requests in flight while the lifecycle moves under them.
+	reg := racyRegistry(t)
+
+	for round := 0; round < 5; round++ {
+		srv := NewServer(reg, "127.0.0.1:0")
+		if err := srv.Start(); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		base := "http://" + srv.Addr()
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+		for i := 0; i < 6; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c := &http.Client{Timeout: time.Second}
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					for _, p := range []string{"/livez", "/readyz", "/healthz", "/readyz?verbose"} {
+						resp, err := c.Get(base + p)
+						if err != nil {
+							continue // the server is going away; that is the point
+						}
+						io.Copy(io.Discard, resp.Body)
+						resp.Body.Close()
+					}
+					_ = srv.Addr()
+				}
+			}()
+		}
+
+		time.Sleep(20 * time.Millisecond)
+		close(stop)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := srv.Stop(ctx); err != nil {
+			t.Fatalf("round %d: Stop: %v", round, err)
+		}
+		cancel()
+		wg.Wait()
+	}
+}
+
+func TestRaceStopBeforeStartIsANoOp(t *testing.T) {
+	reg := racyRegistry(t)
+	srv := NewServer(reg, "127.0.0.1:0")
+
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop before Start: %v", err)
+	}
+	if got := srv.Addr(); got != "127.0.0.1:0" {
+		t.Fatalf("Addr = %q before Start, want the configured address", got)
+	}
+}
+
+func TestRaceConcurrentStopsAreSafe(t *testing.T) {
+	reg := racyRegistry(t)
+
+	for round := 0; round < 10; round++ {
+		srv := NewServer(reg, "127.0.0.1:0")
+		if err := srv.Start(); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				srv.Stop(ctx)
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+func TestRaceServerCyclesDoNotLeakGoroutines(t *testing.T) {
+	reg := racyRegistry(t)
+	base := runtime.NumGoroutine()
+
+	for i := 0; i < 25; i++ {
+		srv := NewServer(reg, "127.0.0.1:0")
+		if err := srv.Start(); err != nil {
+			t.Fatalf("cycle %d: Start: %v", i, err)
+		}
+
+		resp, err := http.Get("http://" + srv.Addr() + "/readyz")
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := srv.Stop(ctx); err != nil {
+			t.Fatalf("cycle %d: Stop: %v", i, err)
+		}
+		cancel()
+	}
+
+	if got := settled(t, base+4); got > base+4 {
+		t.Fatalf("goroutines %d -> %d after 25 server cycles", base, got)
+	}
+}
+
+func TestRaceHandlerUnderLoadWhileRegistryChurns(t *testing.T) {
+	// The core contract: transports only read a snapshot, so scraping hard must
+	// never disturb — or be disturbed by — the scheduler.
+	reg := health.New(racyConfig(), nil)
+	reg.Critical("db", func(context.Context) error { return nil })
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		reg.Stop(ctx)
+	})
+
+	h := Handler(reg)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, p := range []string{"/livez", "/readyz", "/healthz"} {
+					rec := httptest.NewRecorder()
+					h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+					if rec.Code != http.StatusOK && rec.Code != http.StatusServiceUnavailable {
+						panic("unexpected status " + strconv.Itoa(rec.Code) + " on " + p)
+					}
+					if strings.Contains(rec.Body.String(), "sentinel") {
+						panic("check error text leaked into the body: " + rec.Body.String())
+					}
+				}
+			}
+		}()
+	}
+
+	// Churn the registry underneath the readers.
+	for i := 0; i < 40; i++ {
+		reg.Informational("late"+strconv.Itoa(i), func(context.Context) error {
+			return errSentinel
+		})
+		time.Sleep(time.Millisecond)
+	}
+	reg.Drain()
+
+	time.Sleep(10 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func TestRaceNilServerAndNilRegistryUnderConcurrency(t *testing.T) {
+	var srv *Server
+
+	var reg *health.Registry
+	h := Handler(reg)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_ = srv.Start()
+			_ = srv.Stop(context.Background())
+			_ = srv.Addr()
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+			if rec.Code != http.StatusServiceUnavailable {
+				panic("nil registry served " + strconv.Itoa(rec.Code) + ", want 503")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestOnlyInformationalChecksAreNotReady is the regression test for the spec
+// violation found in review: a registry holding only informational checks
+// reported Ready — and answered /readyz 200 — before any check had run.
+func TestOnlyInformationalChecksAreNotReady(t *testing.T) {
+	reg := health.New(racyConfig(), nil)
+	reg.Informational("rabbit", func(context.Context) error { return nil })
+	reg.Informational("s3", func(context.Context) error { return nil })
+
+	// Deliberately not started: nothing has run, so nothing can be ready.
+	rec := httptest.NewRecorder()
+	Handler(reg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/readyz = %d with only informational checks and no run, want 503; body %q",
+			rec.Code, rec.Body.String())
+	}
+
+	ok, err := reg.ReadyFunc()()
+	if ok {
+		t.Fatal("verdict is true with only informational checks and no completed run")
+	}
+	if err == nil {
+		t.Fatal("false verdict with a nil error")
+	}
+	if !strings.Contains(err.Error(), "liveness or critical") {
+		t.Fatalf("got %q, want an error naming the missing counting checks", err)
+	}
+}
+
+var errSentinel = &sentinelError{}
+
+type sentinelError struct{}
+
+func (*sentinelError) Error() string { return "sentinel-dsn-secret" }

--- a/infra/health/http/server.go
+++ b/infra/health/http/server.go
@@ -1,0 +1,158 @@
+package healthhttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// Server serves the probes on its own listener. A nil *Server is a no-op.
+type Server struct {
+	h    *handler
+	srv  *http.Server
+	addr string
+	log  *slog.Logger
+
+	// mu guards what a second Start or a concurrent Addr would race.
+	mu      sync.Mutex
+	ln      net.Listener
+	started bool
+}
+
+// NewServer builds a probe server, or nil when addr is empty.
+func NewServer(r *health.Registry, addr string, opts ...Option) *Server {
+	if addr == "" {
+		return nil
+	}
+
+	o := newOptions(opts)
+	h := newHandler(r, o, false, "") // verbose is granted in serve, once the address is known
+
+	return &Server{
+		h: h,
+		srv: &http.Server{
+			Handler:           h,
+			ReadHeaderTimeout: 5 * time.Second, // Slowloris; the repo has no linter to remind us
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       60 * time.Second,
+			MaxHeaderBytes:    1 << 13,
+			ErrorLog:          slog.NewLogLogger(o.log.Handler(), slog.LevelWarn),
+		},
+		addr: addr,
+		log:  o.log,
+	}
+}
+
+// Start binds the listener, then serves in the background. Calling it twice
+// returns an error rather than binding a second port.
+func (s *Server) Start() error {
+	if s == nil {
+		return nil
+	}
+
+	// Listen synchronously: ListenAndServe in a goroutine returns nil on a taken
+	// port and surfaces the bind error only later, in a log line.
+	l, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("health/http: listen %s: %w", s.addr, err)
+	}
+
+	if err := s.serve(l); err != nil {
+		l.Close()
+
+		return err
+	}
+
+	return nil
+}
+
+// serve is the seam the tests use to present a non-loopback address.
+func (s *Server) serve(l net.Listener) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+
+		return errors.New("health/http: server is already started")
+	}
+	s.started = true
+	s.ln = l
+
+	verbose := loopbackOnly(l.Addr())
+	s.h.verboseAllowed.Store(verbose)
+	s.mu.Unlock()
+
+	if !verbose {
+		s.log.Warn("health/http: ?verbose refused, the listener is not loopback", "addr", l.Addr())
+	}
+
+	go func() {
+		if err := s.srv.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.log.Error("health/http: server failed", "err", err)
+		}
+	}()
+
+	s.log.Info("health/http: listening", "addr", l.Addr())
+
+	return nil
+}
+
+// Stop shuts the server down, bounded by ctx and by its own timeout. Stopping a
+// server that was never started is a no-op, not an error.
+func (s *Server) Stop(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	started := s.started
+	s.mu.Unlock()
+
+	if !started {
+		return nil
+	}
+
+	s.log.Info("health/http: stopping")
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	return s.srv.Shutdown(ctx)
+}
+
+// Addr reports the bound address once listening, otherwise the configured one.
+func (s *Server) Addr() string {
+	if s == nil {
+		return ""
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.ln != nil {
+		return s.ln.Addr().String()
+	}
+
+	return s.addr
+}
+
+// loopbackOnly decides from the bound listener, never from the configured
+// string: net.Listen has already resolved it, so the address is a concrete IP.
+// No name is resolved here — a lookup would be both a side effect and a TOCTOU
+// window, which is why example.com is not loopback to this rule.
+func loopbackOnly(a net.Addr) bool {
+	host, _, err := net.SplitHostPort(a.String())
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+
+	return ip != nil && ip.IsLoopback()
+}

--- a/infra/health/http/server.go
+++ b/infra/health/http/server.go
@@ -39,7 +39,7 @@ func NewServer(r *health.Registry, addr string, opts ...Option) *Server {
 		h: h,
 		srv: &http.Server{
 			Handler:           h,
-			ReadHeaderTimeout: 5 * time.Second, // Slowloris; the repo has no linter to remind us
+			ReadHeaderTimeout: 5 * time.Second,
 			ReadTimeout:       10 * time.Second,
 			WriteTimeout:      10 * time.Second,
 			IdleTimeout:       60 * time.Second,
@@ -58,8 +58,7 @@ func (s *Server) Start() error {
 		return nil
 	}
 
-	// Listen synchronously: ListenAndServe in a goroutine returns nil on a taken
-	// port and surfaces the bind error only later, in a log line.
+	// Listen synchronously so a bind error is returned, not just logged.
 	l, err := net.Listen("tcp", s.addr)
 	if err != nil {
 		return fmt.Errorf("health/http: listen %s: %w", s.addr, err)
@@ -104,8 +103,7 @@ func (s *Server) serve(l net.Listener) error {
 	return nil
 }
 
-// Stop shuts the server down, bounded by ctx and by its own timeout. Stopping a
-// server that was never started is a no-op, not an error.
+// Stop shuts the server down, bounded by ctx. Never started is a no-op.
 func (s *Server) Stop(ctx context.Context) error {
 	if s == nil {
 		return nil
@@ -144,9 +142,7 @@ func (s *Server) Addr() string {
 }
 
 // loopbackOnly decides from the bound listener, never from the configured
-// string: net.Listen has already resolved it, so the address is a concrete IP.
-// No name is resolved here — a lookup would be both a side effect and a TOCTOU
-// window, which is why example.com is not loopback to this rule.
+// string, and resolves no names.
 func loopbackOnly(a net.Addr) bool {
 	host, _, err := net.SplitHostPort(a.String())
 	if err != nil {

--- a/infra/health/http/server_test.go
+++ b/infra/health/http/server_test.go
@@ -1,0 +1,210 @@
+package healthhttp
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// fakeAddr lets a test present any address while the socket stays on loopback.
+type fakeAddr string
+
+func (a fakeAddr) Network() string { return "tcp" }
+func (a fakeAddr) String() string  { return string(a) }
+
+// lyingListener is a real loopback listener that reports someone else's
+// address, so the non-loopback path is exercised without binding a public port.
+type lyingListener struct {
+	net.Listener
+	addr net.Addr
+}
+
+func (l lyingListener) Addr() net.Addr { return l.addr }
+
+func stopServerAtCleanup(t *testing.T, srv *Server) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		if err := srv.Stop(ctx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+}
+
+func startServer(t *testing.T, reg *health.Registry) *Server {
+	t.Helper()
+
+	srv := NewServer(reg, "127.0.0.1:0")
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	stopServerAtCleanup(t, srv)
+
+	return srv
+}
+
+// fetch does a real HTTP GET and returns the status, body and headers.
+func fetch(t *testing.T, url string) (int, string, http.Header) {
+	t.Helper()
+
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("reading %s: %v", url, err)
+	}
+
+	return res.StatusCode, string(body), res.Header
+}
+
+func TestNilServer(t *testing.T) {
+	srv := NewServer(okRegistry(t), "")
+	if srv != nil {
+		t.Fatal("NewServer with an empty address is not nil")
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start on a nil Server: %v", err)
+	}
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop on a nil Server: %v", err)
+	}
+	if got := srv.Addr(); got != "" {
+		t.Fatalf("Addr on a nil Server = %q, want empty", got)
+	}
+}
+
+func TestServerServesProbes(t *testing.T) {
+	reg := okRegistry(t)
+	srv := startServer(t, reg)
+
+	if _, _, err := net.SplitHostPort(srv.Addr()); err != nil {
+		t.Fatalf("Addr = %q, want a bound host:port: %v", srv.Addr(), err)
+	}
+
+	code, body, _ := fetch(t, "http://"+srv.Addr()+"/readyz")
+	want := get(Handler(reg), "/readyz")
+	if code != want.Code || body != want.Body.String() {
+		t.Fatalf("server answered %d %q, mounted handler answered %d %q",
+			code, body, want.Code, want.Body.String())
+	}
+}
+
+func TestStartBindError(t *testing.T) {
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer held.Close()
+
+	srv := NewServer(okRegistry(t), held.Addr().String())
+
+	err = srv.Start()
+	if err == nil {
+		t.Fatal("Start on a busy port returned nil")
+	}
+	if !strings.Contains(err.Error(), held.Addr().String()) {
+		t.Fatalf("error %q does not mention the address %q", err, held.Addr())
+	}
+}
+
+func TestStopIdempotent(t *testing.T) {
+	srv := NewServer(okRegistry(t), "127.0.0.1:0")
+
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop before Start: %v", err)
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("first Stop: %v", err)
+	}
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}
+
+func TestVerboseOnLoopback(t *testing.T) {
+	srv := startServer(t, okRegistry(t))
+
+	code, body, header := fetch(t, "http://"+srv.Addr()+"/readyz?verbose")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", code, http.StatusOK)
+	}
+	if got := header.Get("Content-Type"); got != jsonCT {
+		t.Fatalf("Content-Type = %q, want %q", got, jsonCT)
+	}
+	if !strings.HasPrefix(body, `{"status":"`+health.NameReady+`"`) {
+		t.Fatalf("body = %q, want the D1 JSON", body)
+	}
+}
+
+func TestVerboseRefusedOffLoopback(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	off := fakeAddr("192.168.1.10:8080")
+	srv := NewServer(failingRegistry(t), off.String())
+	// serve() bypasses Start(), so the Serve goroutine is ours to stop —
+	// otherwise -count=3 accumulates three of them.
+	stopServerAtCleanup(t, srv)
+	if err := srv.serve(lyingListener{Listener: l, addr: off}); err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+
+	_, body, header := fetch(t, "http://"+l.Addr().String()+"/readyz?verbose")
+	if got := header.Get("Content-Type"); got != textCT {
+		t.Fatalf("Content-Type = %q, want %q", got, textCT)
+	}
+	if body != health.NameNotReady+"\n" {
+		t.Fatalf("body = %q, want the one-word body", body)
+	}
+	assertNoSentinel(t, "off-loopback /readyz?verbose", body, header)
+}
+
+func TestLoopbackOnly(t *testing.T) {
+	bound, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer bound.Close()
+
+	for _, tt := range []struct {
+		addr net.Addr
+		want bool
+	}{
+		{fakeAddr(":8080"), false},
+		{fakeAddr("0.0.0.0:8080"), false},
+		{fakeAddr("[::]:8080"), false},
+		{fakeAddr("127.0.0.1:8080"), true},
+		{fakeAddr("127.5.5.5:8080"), true}, // all of 127/8
+		{fakeAddr("[::1]:8080"), true},
+		{fakeAddr("[::ffff:127.0.0.1]:8080"), true},
+		{fakeAddr("localhost:8080"), false}, // a listener never reports a name
+		{fakeAddr("192.168.1.10:8080"), false},
+		{fakeAddr("example.com:80"), false}, // no DNS lookup is attempted, deliberately
+		{fakeAddr("localhost"), false},      // no port: SplitHostPort errors
+		{bound.Addr(), true},
+	} {
+		t.Run(tt.addr.String(), func(t *testing.T) {
+			if got := loopbackOnly(tt.addr); got != tt.want {
+				t.Fatalf("loopbackOnly(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}

--- a/infra/health/race_test.go
+++ b/infra/health/race_test.go
@@ -1,0 +1,411 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests exist to be run under -race. Most of them assert nothing beyond
+// "no race, no panic, no deadlock, no leak" — the detector and the test timeout
+// are the assertions. CI runs `go test -race` on every module, so a regression
+// here fails the build rather than surfacing in production.
+
+// hammer runs fn in n goroutines, released together so they collide, and waits.
+func hammer(n int, fn func(i int)) {
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+
+	start.Add(1)
+	for i := 0; i < n; i++ {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+			fn(i)
+		}(i)
+	}
+
+	start.Done()
+	done.Wait()
+}
+
+// goroutinesSettled waits for the goroutine count to come back to at most want,
+// so a slow-exiting goroutine is not reported as a leak.
+func goroutinesSettled(t *testing.T, want int) int {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	got := runtime.NumGoroutine()
+	for time.Now().Before(deadline) {
+		got = runtime.NumGoroutine()
+		if got <= want {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	return got
+}
+
+func racyConfig() Config {
+	return Config{
+		Interval:      time.Millisecond,
+		Timeout:       500 * time.Microsecond,
+		FailThreshold: 1,
+		MinUnready:    time.Microsecond,
+		StaleAfter:    50 * time.Millisecond,
+		DrainHold:     time.Millisecond,
+	}
+}
+
+func TestRaceRegisterWhileRunning(t *testing.T) {
+	// Engine registers dependencies one at a time as they come up, so
+	// registration collides with the scheduler by design.
+	reg := start(t, racyConfig())
+
+	hammer(64, func(i int) {
+		reg.Critical("c"+strconv.Itoa(i), func(context.Context) error { return nil })
+	})
+
+	waitFor(t, "every check to run", func() bool {
+		for _, r := range reg.results() {
+			if r.Status != StatusOK {
+				return false
+			}
+		}
+
+		return len(reg.results()) == 64
+	})
+}
+
+func TestRaceRegisterAndReadConcurrently(t *testing.T) {
+	// Registration takes the write path while Snapshot/ReadyFunc take the read
+	// path, all under the one mutex.
+	reg := start(t, racyConfig())
+	ready := reg.ReadyFunc()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				s := reg.Snapshot()
+				_ = s.State.String()
+				for _, c := range s.Checks {
+					_ = c.Name + c.Status.String() + c.Group.String()
+				}
+				ok, err := ready()
+				if !ok && err == nil {
+					panic("invariant broken: false verdict with a nil error")
+				}
+			}
+		}()
+	}
+
+	hammer(48, func(i int) {
+		reg.Informational("late"+strconv.Itoa(i), func(context.Context) error { return nil })
+	})
+
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func TestRaceDuplicateRegistrationIsSerialised(t *testing.T) {
+	// Every goroutine registers the same name; exactly one must win.
+	reg := New(racyConfig(), nil)
+
+	hammer(32, func(i int) {
+		reg.Critical("db", func(context.Context) error { return nil })
+	})
+
+	if got := len(reg.results()); got != 1 {
+		t.Fatalf("got %d checks named db, want 1", got)
+	}
+}
+
+func TestRaceConcurrentDrainAndStop(t *testing.T) {
+	// A signal handler and a shutdown path can both fire; neither may panic and
+	// Stop must stay idempotent.
+	for round := 0; round < 20; round++ {
+		reg := New(racyConfig(), nil)
+		reg.Critical("db", func(context.Context) error { return nil })
+		if err := reg.Start(context.Background()); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		var errs [8]error
+		hammer(8, func(i int) {
+			if i%2 == 0 {
+				reg.Drain()
+
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			errs[i] = reg.Stop(ctx)
+		})
+
+		for i, err := range errs {
+			if err != nil {
+				t.Fatalf("round %d: Stop from goroutine %d: %v", round, i, err)
+			}
+		}
+		if s := reg.Snapshot(); s.State != StateStopping {
+			t.Fatalf("round %d: state after Drain+Stop = %s, want %s", round, s.State, NameStopping)
+		}
+	}
+}
+
+func TestRaceStartStopCyclesDoNotLeakGoroutines(t *testing.T) {
+	base := runtime.NumGoroutine()
+
+	for i := 0; i < 30; i++ {
+		reg := New(racyConfig(), nil)
+		for j := 0; j < 8; j++ {
+			reg.Critical("c"+strconv.Itoa(j), func(context.Context) error { return nil })
+		}
+		if err := reg.Start(context.Background()); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := reg.Stop(ctx); err != nil {
+			t.Fatalf("cycle %d: Stop: %v", i, err)
+		}
+		cancel()
+	}
+
+	if got := goroutinesSettled(t, base+2); got > base+2 {
+		t.Fatalf("goroutines %d -> %d after 30 start/stop cycles with 8 checks each", base, got)
+	}
+}
+
+func TestRaceParentContextCancelRacesStop(t *testing.T) {
+	// The parent ctx dying and an explicit Stop are two independent shutdown
+	// triggers; together they must still terminate cleanly.
+	base := runtime.NumGoroutine()
+
+	for i := 0; i < 20; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		reg := New(racyConfig(), nil)
+		reg.Critical("db", func(c context.Context) error { <-c.Done(); return c.Err() })
+		if err := reg.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		hammer(2, func(i int) {
+			if i == 0 {
+				cancel()
+
+				return
+			}
+			sctx, scancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer scancel()
+			reg.Stop(sctx)
+		})
+
+		cancel()
+	}
+
+	if got := goroutinesSettled(t, base+2); got > base+2 {
+		t.Fatalf("goroutines %d -> %d after 20 cancel/stop races", base, got)
+	}
+}
+
+func TestRacePanickingCheckDoesNotCorruptTheRegistry(t *testing.T) {
+	// A panic becomes that check's error. Under concurrency it must not take
+	// the process down or wedge the mutex.
+	reg := start(t, racyConfig())
+
+	for i := 0; i < 16; i++ {
+		name := "boom" + strconv.Itoa(i)
+		reg.Critical(name, func(context.Context) error { panic("kaboom " + name) })
+	}
+	reg.Informational("fine", func(context.Context) error { return nil })
+
+	waitFor(t, "the healthy check to pass despite the panics", func() bool {
+		for _, r := range reg.results() {
+			if r.Name == "fine" && r.Status == StatusOK {
+				return true
+			}
+		}
+
+		return false
+	})
+
+	ok, err := reg.ReadyFunc()()
+	if ok {
+		t.Fatal("verdict is true with sixteen panicking critical checks")
+	}
+	if err == nil {
+		t.Fatal("false verdict with a nil error")
+	}
+}
+
+func TestRaceReadyFuncClosureOutlivesTheRegistry(t *testing.T) {
+	// Consul holds the closure for the process lifetime; it must stay safe
+	// after Stop and must never return (false, nil).
+	reg := New(racyConfig(), nil)
+	reg.Critical("db", func(context.Context) error { return errors.New("down") })
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	ready := reg.ReadyFunc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := reg.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	hammer(32, func(int) {
+		for i := 0; i < 50; i++ {
+			ok, err := ready()
+			if !ok && err == nil {
+				panic("invariant broken after Stop: false verdict with a nil error")
+			}
+		}
+	})
+}
+
+func TestRaceSnapshotIsAnIndependentCopy(t *testing.T) {
+	// Transports hold a Snapshot while the scheduler keeps recording; mutating
+	// or reading the returned slice must not touch registry state.
+	reg := start(t, racyConfig())
+	for i := 0; i < 16; i++ {
+		reg.Critical("c"+strconv.Itoa(i), func(context.Context) error { return nil })
+	}
+
+	waitFor(t, "checks to appear", func() bool { return len(reg.Snapshot().Checks) == 16 })
+
+	hammer(16, func(int) {
+		for i := 0; i < 100; i++ {
+			s := reg.Snapshot()
+			for j := range s.Checks {
+				s.Checks[j].Name = "clobbered"
+				s.Checks[j].Status = StatusFail
+			}
+		}
+	})
+
+	for _, c := range reg.Snapshot().Checks {
+		if c.Name == "clobbered" {
+			t.Fatal("a caller mutating Snapshot().Checks corrupted the registry")
+		}
+	}
+}
+
+func TestRaceHysteresisUnderConcurrentReads(t *testing.T) {
+	// A flapping check drives status transitions while readers hammer the
+	// snapshot — the classic shape for a torn read.
+	var flip atomic.Bool
+
+	cfg := racyConfig()
+	cfg.FailThreshold = 2
+	reg := start(t, cfg)
+	reg.Critical("flappy", func(context.Context) error {
+		if flip.Load() {
+			return errors.New("down")
+		}
+
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				s := reg.Snapshot()
+				for _, c := range s.Checks {
+					// Since must never be in the future of the snapshot.
+					if !c.Since.IsZero() && c.Since.After(s.Time) {
+						panic(fmt.Sprintf("check %q Since %v is after Snapshot.Time %v", c.Name, c.Since, s.Time))
+					}
+					if c.Status != StatusOK && c.Err == nil {
+						panic("check " + c.Name + " is " + c.Status.String() + " with a nil Err")
+					}
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 60; i++ {
+		flip.Store(i%2 == 0)
+		time.Sleep(time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+func TestRaceNilRegistryUnderConcurrency(t *testing.T) {
+	var reg *Registry
+
+	hammer(32, func(i int) {
+		reg.Critical("db", func(context.Context) error { return nil })
+		reg.Drain()
+		_ = reg.Start(context.Background())
+		_ = reg.Stop(context.Background())
+		s := reg.Snapshot()
+		_ = s.State.String()
+		ok, err := reg.ReadyFunc()()
+		if !ok && err == nil {
+			panic("nil registry returned a false verdict with a nil error")
+		}
+	})
+}
+
+func TestRaceCheckIgnoringContextDoesNotBlockShutdown(t *testing.T) {
+	// The pathological consumer: a check that never returns. Stop must still
+	// come back, and must say so honestly.
+	release := make(chan struct{})
+	defer close(release)
+
+	reg := New(racyConfig(), nil)
+	for i := 0; i < 8; i++ {
+		reg.Critical("hung"+strconv.Itoa(i), func(context.Context) error { <-release; return nil })
+	}
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- reg.Stop(ctx) }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop hung on checks that ignore their context")
+	}
+}

--- a/infra/health/registry.go
+++ b/infra/health/registry.go
@@ -10,15 +10,13 @@ import (
 	"time"
 )
 
-// Registry runs checks in the background, one goroutine per check, and caches
-// the last result. Every method is safe for concurrent use and on a nil
-// *Registry. The zero value is not usable; use New.
+// Registry runs checks in the background and caches the last result. Every
+// method is safe for concurrent use and on a nil *Registry. Use New.
 type Registry struct {
 	cfg Config
 	log *slog.Logger
 
-	// mu guards everything below, including every checkState, and is never
-	// held while a check runs.
+	// mu guards everything below and is never held while a check runs.
 	mu        sync.Mutex
 	checks    map[string]*checkState
 	ctx       context.Context // nil until Start
@@ -62,8 +60,7 @@ func (r *Registry) Critical(name string, fn Check) { r.register(name, GroupCriti
 // Informational registers a check whose failure only degrades the node.
 func (r *Registry) Informational(name string, fn Check) { r.register(name, GroupInformational, fn) }
 
-// register adds a check, starting its goroutine at once when called after Start.
-// Bad input is logged and dropped: registration has no error to return.
+// register adds a check, starting its goroutine at once when already running.
 func (r *Registry) register(name string, group Group, fn Check) {
 	if r == nil {
 		return
@@ -91,7 +88,6 @@ func (r *Registry) register(name string, group Group, fn Check) {
 	cs := &checkState{name: name, group: group, fn: fn}
 	r.checks[name] = cs
 
-	// Engine brings dependencies up one at a time, so this must work after Start.
 	if r.started {
 		r.wg.Add(1)
 		go r.run(r.ctx, cs)
@@ -128,8 +124,7 @@ func (r *Registry) Start(ctx context.Context) error {
 	return nil
 }
 
-// Drain switches to not-ready, one way. It returns at once; the DrainHold wait
-// happens in Stop.
+// Drain switches to not-ready, one way. The DrainHold wait happens in Stop.
 func (r *Registry) Drain() {
 	if r == nil {
 		return
@@ -147,8 +142,7 @@ func (r *Registry) Drain() {
 	r.log.Info("health: draining", "hold", r.cfg.DrainHold)
 }
 
-// Stop halts the scheduler, bounded by ctx. After Drain it first waits out the
-// rest of DrainHold so service discovery sees us as not-ready.
+// Stop halts the scheduler, bounded by ctx, after waiting out any DrainHold.
 func (r *Registry) Stop(ctx context.Context) error {
 	if r == nil {
 		return nil
@@ -159,7 +153,6 @@ func (r *Registry) Stop(ctx context.Context) error {
 		done := r.stopDone
 		r.mu.Unlock()
 
-		// Another Stop got there first; wait for it, bounded by our ctx.
 		select {
 		case <-done:
 			return nil
@@ -173,8 +166,7 @@ func (r *Registry) Stop(ctx context.Context) error {
 
 	defer close(r.stopDone)
 
-	// The hold only matters if checks actually ran: a never-started registry
-	// was never ready, so there is nothing for service discovery to notice.
+	// A never-started registry was never ready, so there is nothing to hold for.
 	if draining && started {
 		if err := wait(ctx, r.cfg.DrainHold-time.Since(drainAt)); err != nil {
 			r.log.Warn("health: drain hold cut short", "err", err)
@@ -196,8 +188,8 @@ func (r *Registry) results() []CheckResult {
 	return r.Snapshot().Checks
 }
 
-// run is one check's whole life: run, wait one Interval, repeat. The wait starts
-// after the run, so a slow check is not re-run back to back as a Ticker would.
+// run is one check's whole life. The wait starts after the run, so a slow check
+// is not re-run back to back as a Ticker would.
 func (r *Registry) run(ctx context.Context, cs *checkState) {
 	defer r.wg.Done()
 
@@ -226,7 +218,7 @@ func (r *Registry) runOnce(ctx context.Context, cs *checkState) {
 		return // shutting down, not the check's fault
 	}
 	if err == nil && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-		// Ignored its context and finished late. Late is not passing.
+		// Finished late: that is not passing.
 		err = fmt.Errorf("check %q passed only after its %s timeout", cs.name, r.cfg.Timeout)
 	}
 

--- a/infra/health/registry.go
+++ b/infra/health/registry.go
@@ -1,0 +1,300 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+// Registry runs checks in the background, one goroutine per check, and caches
+// the last result. Every method is safe for concurrent use and on a nil
+// *Registry. The zero value is not usable; use New.
+type Registry struct {
+	cfg Config
+	log *slog.Logger
+
+	// mu guards everything below, including every checkState, and is never
+	// held while a check runs.
+	mu        sync.Mutex
+	checks    map[string]*checkState
+	ctx       context.Context // nil until Start
+	cancel    context.CancelFunc
+	started   bool
+	startedAt time.Time
+	stopped   bool
+	draining  bool
+	drainAt   time.Time
+	stopDone  chan struct{} // closed when the first Stop call finishes
+
+	wg sync.WaitGroup
+}
+
+// New builds a registry. A nil logger discards.
+func New(cfg Config, log *slog.Logger) *Registry {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+
+	cfg = cfg.withDefaults()
+	if cfg.Timeout >= cfg.Interval {
+		log.Warn("health: Timeout is not smaller than Interval, checks cannot keep to schedule",
+			"timeout", cfg.Timeout, "interval", cfg.Interval)
+	}
+
+	return &Registry{
+		cfg:      cfg,
+		log:      log,
+		checks:   make(map[string]*checkState),
+		stopDone: make(chan struct{}),
+	}
+}
+
+// Liveness registers a check that answers "is this process wedged?".
+func (r *Registry) Liveness(name string, fn Check) { r.register(name, GroupLiveness, fn) }
+
+// Critical registers a check whose failure takes the node out of rotation.
+func (r *Registry) Critical(name string, fn Check) { r.register(name, GroupCritical, fn) }
+
+// Informational registers a check whose failure only degrades the node.
+func (r *Registry) Informational(name string, fn Check) { r.register(name, GroupInformational, fn) }
+
+// register adds a check, starting its goroutine at once when called after Start.
+// Bad input is logged and dropped: registration has no error to return.
+func (r *Registry) register(name string, group Group, fn Check) {
+	if r == nil {
+		return
+	}
+	if name == "" || fn == nil {
+		r.log.Error("health: ignoring check with empty name or nil function", "check", name)
+
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.stopped {
+		r.log.Error("health: ignoring check registered after Stop", "check", name)
+
+		return
+	}
+	if _, exists := r.checks[name]; exists {
+		r.log.Error("health: ignoring duplicate check name", "check", name)
+
+		return
+	}
+
+	cs := &checkState{name: name, group: group, fn: fn}
+	r.checks[name] = cs
+
+	// Engine brings dependencies up one at a time, so this must work after Start.
+	if r.started {
+		r.wg.Add(1)
+		go r.run(r.ctx, cs)
+	}
+}
+
+// Start begins running every registered check. It does not block.
+func (r *Registry) Start(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.stopped {
+		return errors.New("health: registry is stopped")
+	}
+	if r.started {
+		return errors.New("health: registry is already started")
+	}
+
+	r.ctx, r.cancel = context.WithCancel(ctx)
+	r.started = true
+	r.startedAt = time.Now()
+
+	for _, cs := range r.checks {
+		r.wg.Add(1)
+		go r.run(r.ctx, cs)
+	}
+
+	r.log.Info("health: started", "checks", len(r.checks), "interval", r.cfg.Interval)
+
+	return nil
+}
+
+// Drain switches to not-ready, one way. It returns at once; the DrainHold wait
+// happens in Stop.
+func (r *Registry) Drain() {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.draining {
+		return
+	}
+
+	r.draining = true
+	r.drainAt = time.Now()
+	r.log.Info("health: draining", "hold", r.cfg.DrainHold)
+}
+
+// Stop halts the scheduler, bounded by ctx. After Drain it first waits out the
+// rest of DrainHold so service discovery sees us as not-ready.
+func (r *Registry) Stop(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	if r.stopped {
+		done := r.stopDone
+		r.mu.Unlock()
+
+		// Another Stop got there first; wait for it, bounded by our ctx.
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	r.stopped = true
+	cancel, started, draining, drainAt := r.cancel, r.started, r.draining, r.drainAt
+	r.mu.Unlock()
+
+	defer close(r.stopDone)
+
+	// The hold only matters if checks actually ran: a never-started registry
+	// was never ready, so there is nothing for service discovery to notice.
+	if draining && started {
+		if err := wait(ctx, r.cfg.DrainHold-time.Since(drainAt)); err != nil {
+			r.log.Warn("health: drain hold cut short", "err", err)
+		}
+	}
+
+	if cancel != nil {
+		cancel()
+	}
+	if !started {
+		return nil
+	}
+
+	return r.join(ctx)
+}
+
+// results returns every check's state, sorted by name.
+func (r *Registry) results() []CheckResult {
+	return r.Snapshot().Checks
+}
+
+// run is one check's whole life: run, wait one Interval, repeat. The wait starts
+// after the run, so a slow check is not re-run back to back as a Ticker would.
+func (r *Registry) run(ctx context.Context, cs *checkState) {
+	defer r.wg.Done()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		r.runOnce(ctx, cs)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.cfg.Interval):
+		}
+	}
+}
+
+func (r *Registry) runOnce(ctx context.Context, cs *checkState) {
+	runCtx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
+	defer cancel()
+
+	err := r.call(runCtx, cs)
+
+	if ctx.Err() != nil {
+		return // shutting down, not the check's fault
+	}
+	if err == nil && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		// Ignored its context and finished late. Late is not passing.
+		err = fmt.Errorf("check %q passed only after its %s timeout", cs.name, r.cfg.Timeout)
+	}
+
+	r.record(cs, err)
+}
+
+// call runs the check; a panic becomes that check's error.
+func (r *Registry) call(ctx context.Context, cs *checkState) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			r.log.Error("health: check panicked",
+				"check", cs.name, "panic", p, "stack", string(debug.Stack()))
+			err = fmt.Errorf("check %q panicked: %v", cs.name, p)
+		}
+	}()
+
+	return cs.fn(ctx)
+}
+
+func (r *Registry) record(cs *checkState, err error) {
+	r.mu.Lock()
+	status, changed := cs.record(time.Now(), err, r.cfg)
+	r.mu.Unlock()
+
+	if !changed {
+		return
+	}
+
+	if status == StatusFail {
+		r.log.Warn("health: check is failing", "check", cs.name, "group", cs.group, "err", err)
+
+		return
+	}
+
+	r.log.Info("health: check recovered", "check", cs.name, "group", cs.group, "status", status)
+}
+
+// join waits for the check goroutines, bounded by ctx.
+func (r *Registry) join(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		r.log.Info("health: stopped")
+
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("health: stopped with checks still running: %w", ctx.Err())
+	}
+}
+
+// wait sleeps for d, or until ctx is done.
+func wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/infra/health/registry_test.go
+++ b/infra/health/registry_test.go
@@ -155,8 +155,9 @@ func TestSlowRunsAreStillSpacedByAnInterval(t *testing.T) {
 	for i := 1; i < 3; i++ {
 		// Every gap must be at least run duration + Interval; a buffered
 		// tick would make it just the run duration.
-		if gap := starts[i].Sub(starts[i-1]); gap < sleep+cfg.Interval/2 {
-			t.Fatalf("runs %d and %d started %s apart, want at least %s", i-1, i, gap, sleep+cfg.Interval)
+		if want := sleep + cfg.Interval/2; starts[i].Sub(starts[i-1]) < want {
+			t.Fatalf("runs %d and %d started %s apart, want at least %s",
+				i-1, i, starts[i].Sub(starts[i-1]), want)
 		}
 	}
 }

--- a/infra/health/registry_test.go
+++ b/infra/health/registry_test.go
@@ -1,0 +1,479 @@
+package health
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testConfig scales every timing down so the scheduler's behaviour is visible
+// in milliseconds. Nothing here is faked: these are the real tickers and the
+// real contexts, which is the point under -race.
+func testConfig() Config {
+	return Config{
+		Interval:      20 * time.Millisecond,
+		Timeout:       10 * time.Millisecond,
+		FailThreshold: 1,
+		MinUnready:    time.Millisecond,
+		StaleAfter:    2 * time.Second,
+		DrainHold:     time.Millisecond,
+	}
+}
+
+// waitFor polls until cond holds, or fails the test.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// start builds a started registry and stops it when the test ends.
+func start(t *testing.T, cfg Config) *Registry {
+	t.Helper()
+
+	reg := New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		reg.Stop(ctx)
+	})
+
+	return reg
+}
+
+func find(reg *Registry, name string) CheckResult {
+	for _, res := range reg.results() {
+		if res.Name == name {
+			return res
+		}
+	}
+
+	return CheckResult{}
+}
+
+func TestCheckRunsInBackground(t *testing.T) {
+	reg := start(t, testConfig())
+	reg.Critical("ok", func(context.Context) error { return nil })
+
+	waitFor(t, "check to pass", func() bool { return find(reg, "ok").Status == StatusOK })
+}
+
+func TestRegistrationWorksAfterStart(t *testing.T) {
+	// Engine brings its dependencies up one at a time, so it cannot hand the
+	// registry a complete set at construction.
+	reg := start(t, testConfig())
+
+	waitFor(t, "an empty registry", func() bool { return len(reg.results()) == 0 })
+
+	reg.Informational("late", func(context.Context) error { return nil })
+
+	waitFor(t, "the late check to run", func() bool { return find(reg, "late").Status == StatusOK })
+}
+
+func TestPanicBecomesTheChecksError(t *testing.T) {
+	reg := start(t, testConfig())
+	reg.Critical("boom", func(context.Context) error { panic("kaboom") })
+
+	waitFor(t, "the panic to be recorded", func() bool { return find(reg, "boom").Status == StatusFail })
+
+	err := find(reg, "boom").Err
+	if err == nil || !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("got %v, want an error mentioning the panic", err)
+	}
+}
+
+func TestRunsNeverOverlap(t *testing.T) {
+	// The check below ignores its context, which is exactly the case the
+	// "one run at a time" rule exists for: a context deadline does not kill a
+	// goroutine, so if the scheduler moved on at the deadline these would pile
+	// up and drain the very pool the check is probing.
+	var runs atomic.Int32
+	release := make(chan struct{})
+	defer close(release)
+
+	reg := start(t, testConfig())
+	reg.Critical("hung", func(context.Context) error {
+		runs.Add(1)
+		<-release
+
+		return nil
+	})
+
+	waitFor(t, "the check to start", func() bool { return runs.Load() == 1 })
+
+	// Give the scheduler many intervals in which it could wrongly start more.
+	time.Sleep(20 * testConfig().Interval)
+
+	if got := runs.Load(); got != 1 {
+		t.Fatalf("the check started %d times while the first was still running, want 1", got)
+	}
+}
+
+func TestSlowRunsAreStillSpacedByAnInterval(t *testing.T) {
+	// A Ticker would buffer a tick during a slower-than-Interval run and
+	// re-run the check back to back — hammering the dependency the moment it
+	// gets slow, which is the opposite of what a health check should do.
+	cfg := testConfig()
+	sleep := 3 * cfg.Interval
+
+	var mu sync.Mutex
+	var starts []time.Time
+
+	reg := start(t, cfg)
+	reg.Critical("slow", func(context.Context) error {
+		mu.Lock()
+		starts = append(starts, time.Now())
+		mu.Unlock()
+		time.Sleep(sleep)
+
+		return nil
+	})
+
+	waitFor(t, "three runs", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return len(starts) >= 3
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 1; i < 3; i++ {
+		// Every gap must be at least run duration + Interval; a buffered
+		// tick would make it just the run duration.
+		if gap := starts[i].Sub(starts[i-1]); gap < sleep+cfg.Interval/2 {
+			t.Fatalf("runs %d and %d started %s apart, want at least %s", i-1, i, gap, sleep+cfg.Interval)
+		}
+	}
+}
+
+func TestSlowCheckIsRecordedAsFailed(t *testing.T) {
+	// A well-behaved slow check returns the deadline error it was handed.
+	reg := start(t, testConfig())
+	reg.Critical("slow", func(ctx context.Context) error {
+		<-ctx.Done()
+
+		return ctx.Err()
+	})
+
+	waitFor(t, "the timeout to be recorded", func() bool { return find(reg, "slow").Status == StatusFail })
+}
+
+func TestFinishingLateIsNotPassing(t *testing.T) {
+	// A check that ignores its context and "succeeds" anyway — a query that
+	// came back on the timeout's fourth try, say — must not count as passing.
+	cfg := testConfig()
+
+	reg := start(t, cfg)
+	reg.Critical("late", func(context.Context) error {
+		time.Sleep(3 * cfg.Timeout)
+
+		return nil
+	})
+
+	waitFor(t, "the late pass to be recorded as a failure", func() bool {
+		return find(reg, "late").Status == StatusFail
+	})
+
+	err := find(reg, "late").Err
+	if err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("got %v, want an error mentioning the timeout", err)
+	}
+}
+
+func TestAHangingCheckGoesStaleRatherThanFailing(t *testing.T) {
+	// A check that stops returning is never recorded again, so its
+	// consecutive-failure count cannot reach FailThreshold and it never
+	// becomes StatusFail. Staleness carries the verdict instead — and
+	// StatusUnknown is not healthy, so the node still leaves rotation.
+	cfg := testConfig()
+	cfg.FailThreshold = 3
+	cfg.StaleAfter = 100 * time.Millisecond
+
+	var runs atomic.Int32
+	release := make(chan struct{})
+	defer close(release)
+
+	reg := start(t, cfg)
+	reg.Critical("db", func(context.Context) error {
+		if runs.Add(1) > 1 {
+			<-release // healthy once, then hangs forever
+		}
+
+		return nil
+	})
+
+	waitFor(t, "the healthy first run", func() bool { return find(reg, "db").Status == StatusOK })
+	waitFor(t, "the result to go stale", func() bool { return find(reg, "db").Status == StatusUnknown })
+}
+
+func TestStopIsNotBlockedByAHungCheck(t *testing.T) {
+	var began atomic.Bool
+	release := make(chan struct{})
+	defer close(release)
+
+	reg := New(testConfig(), nil)
+	reg.Critical("hung", func(context.Context) error {
+		began.Store(true)
+		<-release
+
+		return nil
+	})
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	waitFor(t, "the check to be running", func() bool { return began.Load() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- reg.Stop(ctx) }()
+
+	select {
+	case err := <-done:
+		// Stop must return — and must not pretend the shutdown was clean.
+		if err == nil || !strings.Contains(err.Error(), "still running") {
+			t.Fatalf("got %v, want an error reporting checks still running", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop hung on a check that ignores its context")
+	}
+}
+
+func TestStopAbsorbsTheDrainHold(t *testing.T) {
+	cfg := testConfig()
+	cfg.DrainHold = 200 * time.Millisecond
+
+	reg := New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	reg.Drain()
+
+	began := time.Now()
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if held := time.Since(began); held < cfg.DrainHold/2 {
+		t.Fatalf("Stop returned after %s, want it to hold for about %s", held, cfg.DrainHold)
+	}
+}
+
+func TestDrainHoldIsBoundedByTheContext(t *testing.T) {
+	cfg := testConfig()
+	cfg.DrainHold = 10 * time.Second
+
+	reg := New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	reg.Drain()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	began := time.Now()
+	reg.Stop(ctx)
+
+	if held := time.Since(began); held > time.Second {
+		t.Fatalf("Stop held for %s despite the context deadline", held)
+	}
+}
+
+func TestStopWithoutDrainDoesNotHold(t *testing.T) {
+	cfg := testConfig()
+	cfg.DrainHold = 10 * time.Second
+
+	reg := New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	began := time.Now()
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if held := time.Since(began); held > time.Second {
+		t.Fatalf("Stop held for %s without a preceding Drain", held)
+	}
+}
+
+func TestNoRunAfterTheContextDies(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reg := New(testConfig(), nil)
+	if err := reg.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cancel()
+
+	var runs atomic.Int32
+	reg.Critical("late", func(context.Context) error {
+		runs.Add(1)
+
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := runs.Load(); got != 0 {
+		t.Fatalf("check ran %d times after the context died, want 0", got)
+	}
+}
+
+func TestSecondStopWaitsForTheFirst(t *testing.T) {
+	cfg := testConfig()
+	cfg.DrainHold = 300 * time.Millisecond
+
+	reg := New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	reg.Drain()
+
+	go reg.Stop(context.Background()) // absorbs the DrainHold
+
+	time.Sleep(50 * time.Millisecond)
+
+	began := time.Now()
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if waited := time.Since(began); waited < cfg.DrainHold/3 {
+		t.Fatalf("second Stop returned after %s, before the first finished its %s hold", waited, cfg.DrainHold)
+	}
+}
+
+func TestStopOnNeverStartedRegistrySkipsTheDrainHold(t *testing.T) {
+	cfg := testConfig()
+	cfg.DrainHold = 10 * time.Second
+
+	reg := New(cfg, nil)
+	reg.Drain()
+
+	began := time.Now()
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if held := time.Since(began); held > time.Second {
+		t.Fatalf("Stop held %s on a registry that never started", held)
+	}
+}
+
+func TestDuplicateNameIsIgnoredNotReplaced(t *testing.T) {
+	reg := New(testConfig(), nil)
+	reg.Critical("db", func(context.Context) error { return nil })
+	reg.Informational("db", func(context.Context) error { return nil })
+
+	results := reg.results()
+	if len(results) != 1 {
+		t.Fatalf("got %d checks, want 1", len(results))
+	}
+	if results[0].Group != GroupCritical {
+		t.Fatalf("the duplicate replaced the original: group is %s", results[0].Group)
+	}
+}
+
+func TestUnusableRegistrationsAreIgnored(t *testing.T) {
+	reg := New(testConfig(), nil)
+	reg.Critical("", func(context.Context) error { return nil })
+	reg.Critical("nil-fn", nil)
+
+	if got := len(reg.results()); got != 0 {
+		t.Fatalf("got %d checks, want 0", got)
+	}
+}
+
+func TestRegistrationAfterStopIsIgnored(t *testing.T) {
+	reg := New(testConfig(), nil)
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	reg.Critical("late", func(context.Context) error { return nil })
+
+	if got := len(reg.results()); got != 0 {
+		t.Fatalf("got %d checks, want 0", got)
+	}
+}
+
+func TestStartIsNotRepeatable(t *testing.T) {
+	reg := start(t, testConfig())
+
+	if err := reg.Start(context.Background()); err == nil {
+		t.Fatal("a second Start succeeded, want an error")
+	}
+}
+
+func TestStartAfterStopFails(t *testing.T) {
+	reg := New(testConfig(), nil)
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if err := reg.Start(context.Background()); err == nil {
+		t.Fatal("Start after Stop succeeded, want an error")
+	}
+}
+
+func TestStopIsRepeatable(t *testing.T) {
+	reg := start(t, testConfig())
+
+	for i := 0; i < 3; i++ {
+		if err := reg.Stop(context.Background()); err != nil {
+			t.Fatalf("Stop %d: %v", i, err)
+		}
+	}
+}
+
+func TestNilRegistryIsSafe(t *testing.T) {
+	var reg *Registry
+
+	reg.Critical("db", func(context.Context) error { return nil })
+	reg.Liveness("live", func(context.Context) error { return nil })
+	reg.Informational("info", func(context.Context) error { return nil })
+	reg.Drain()
+
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestPartialConfigIsFilledIn(t *testing.T) {
+	got := Config{Interval: time.Second}.withDefaults()
+	def := DefaultConfig()
+
+	if got.Interval != time.Second {
+		t.Errorf("Interval = %s, want it left alone", got.Interval)
+	}
+	if got.Timeout != def.Timeout || got.FailThreshold != def.FailThreshold {
+		t.Errorf("got %+v, want the unset fields from DefaultConfig", got)
+	}
+}

--- a/infra/health/sdnotify/doc.go
+++ b/infra/health/sdnotify/doc.go
@@ -1,0 +1,28 @@
+// Package sdnotify reports the health registry to systemd over NOTIFY_SOCKET:
+// READY=1 once ready, STATUS= on a state change, STOPPING=1 at shutdown, and
+// WATCHDOG=1 while the registry's scheduler keeps turning.
+//
+// These variables are systemd's interface, so this package reads the
+// environment where the rest of infra/health refuses to. No NOTIFY_SOCKET means
+// [New] returns nil and every method is a no-op. WATCHDOG_USEC and WATCHDOG_PID
+// are read once: the ping period is WATCHDOG_USEC/2, and a foreign WATCHDOG_PID
+// or an unusable value disables the ping. A check's error text never reaches
+// STATUS=, and a notify failure is logged rather than returned.
+//
+// systemd.go holds ~55 lines adapted from github.com/coreos/go-systemd/v22 under
+// Apache 2.0, copied rather than imported to keep the require block empty; its
+// header carries the attribution and the list of modifications.
+//
+// # For WTEL-10090
+//
+// WatchdogSec must be chosen against StaleAfter. The ping is gated on
+// SchedulerAlive, so at period WATCHDOG_USEC/2 one skipped ping already makes
+// the gap exactly WATCHDOG_USEC — the kill threshold. Use
+// WatchdogSec >= 4 x StaleAfter (>= 60s at [health.DefaultConfig]), never below
+// 2 x StaleAfter.
+//
+// Without [WithStartTimeout] there is no READY=1 fallback, so under Type=notify
+// a unit whose critical check never goes green stays in activating until
+// TimeoutStartSec. Type=notify, TimeoutStartSec=90 and WithStartTimeout belong
+// in one commit.
+package sdnotify

--- a/infra/health/sdnotify/doc.go
+++ b/infra/health/sdnotify/doc.go
@@ -1,28 +1,3 @@
-// Package sdnotify reports the health registry to systemd over NOTIFY_SOCKET:
-// READY=1 once ready, STATUS= on a state change, STOPPING=1 at shutdown, and
-// WATCHDOG=1 while the registry's scheduler keeps turning.
-//
-// These variables are systemd's interface, so this package reads the
-// environment where the rest of infra/health refuses to. No NOTIFY_SOCKET means
-// [New] returns nil and every method is a no-op. WATCHDOG_USEC and WATCHDOG_PID
-// are read once: the ping period is WATCHDOG_USEC/2, and a foreign WATCHDOG_PID
-// or an unusable value disables the ping. A check's error text never reaches
-// STATUS=, and a notify failure is logged rather than returned.
-//
-// systemd.go holds ~55 lines adapted from github.com/coreos/go-systemd/v22 under
-// Apache 2.0, copied rather than imported to keep the require block empty; its
-// header carries the attribution and the list of modifications.
-//
-// # For WTEL-10090
-//
-// WatchdogSec must be chosen against StaleAfter. The ping is gated on
-// SchedulerAlive, so at period WATCHDOG_USEC/2 one skipped ping already makes
-// the gap exactly WATCHDOG_USEC — the kill threshold. Use
-// WatchdogSec >= 4 x StaleAfter (>= 60s at [health.DefaultConfig]), never below
-// 2 x StaleAfter.
-//
-// Without [WithStartTimeout] there is no READY=1 fallback, so under Type=notify
-// a unit whose critical check never goes green stays in activating until
-// TimeoutStartSec. Type=notify, TimeoutStartSec=90 and WithStartTimeout belong
-// in one commit.
+// Package sdnotify reports the health registry to systemd over NOTIFY_SOCKET.
+// Without that variable New returns nil and every method is a no-op.
 package sdnotify

--- a/infra/health/sdnotify/helpers_test.go
+++ b/infra/health/sdnotify/helpers_test.go
@@ -1,0 +1,333 @@
+package sdnotify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// socketNonce keeps abstract socket names unique: -count=3 runs three
+// iterations in one process, so a bare PID would collide with itself.
+var socketNonce atomic.Uint64
+
+// notifySocket returns a receiving unixgram socket on a path short enough for
+// darwin's 104-byte sun_path. t.TempDir() is unusable here: on darwin it is
+// already 80 bytes for a short test name and over 125 for a subtest, and the
+// bind then fails with a bare "invalid argument".
+func notifySocket(t *testing.T) (string, *net.UnixConn) {
+	t.Helper()
+
+	// Hermetic by default: a runner that exports a watchdog environment would
+	// otherwise break every "want nothing" assertion in this package, and no
+	// quiet window would ever elapse. The watchdog tests set their own values
+	// after calling this.
+	t.Setenv("WATCHDOG_USEC", "")
+	t.Setenv("WATCHDOG_PID", "")
+
+	// os.TempDir honours TMPDIR, which a sandbox may redirect when /tmp is
+	// read-only. Darwin's per-user TMPDIR is far too long for sun_path, so /tmp
+	// stays the fallback and the length guard below still has the last word.
+	base := os.TempDir()
+	if len(base) > 40 {
+		base = "/tmp"
+	}
+
+	dir, err := os.MkdirTemp(base, "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	addr := filepath.Join(dir, "n.sock")
+	if len(addr) > 100 {
+		t.Fatalf("socket path is %d bytes, too long for this platform: %s", len(addr), addr)
+	}
+
+	ln, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: addr, Net: "unixgram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	return addr, ln
+}
+
+// rebind destroys the receiving socket file and listens on the same path again.
+// The os.Remove is mandatory: net.ListenUnixgram has no unlink-on-close — that
+// lives on UnixListener, the stream type — so the file outlives Close and a
+// second bind fails with "address already in use".
+func rebind(t *testing.T, addr string) *net.UnixConn {
+	t.Helper()
+
+	if err := os.Remove(addr); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: addr, Net: "unixgram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	return ln
+}
+
+// recv reads one datagram.
+func recv(t *testing.T, ln *net.UnixConn, timeout time.Duration) string {
+	t.Helper()
+
+	if err := ln.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 4096)
+	n, err := ln.Read(buf)
+	if err != nil {
+		t.Fatalf("waiting %s for a datagram: %v", timeout, err)
+	}
+
+	return string(buf[:n])
+}
+
+// recvAll reads datagrams until quiet elapses with none arriving. The budget is
+// not optional: against a live watchdog ticker no quiet window ever elapses, and
+// a test that hangs until go test's ten-minute timeout is strictly worse than
+// one that fails legibly in a second.
+func recvAll(t *testing.T, ln *net.UnixConn, quiet, budget time.Duration) []string {
+	t.Helper()
+
+	var got []string
+	end := time.Now().Add(budget)
+
+	for {
+		if time.Now().After(end) {
+			t.Fatalf("no quiet window of %s within %s; got %d datagrams: %q", quiet, budget, len(got), got)
+		}
+		if err := ln.SetReadDeadline(time.Now().Add(quiet)); err != nil {
+			t.Fatal(err)
+		}
+
+		buf := make([]byte, 4096)
+		n, err := ln.Read(buf)
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				return got
+			}
+
+			t.Fatal(err)
+		}
+
+		got = append(got, string(buf[:n]))
+	}
+}
+
+// countEqual counts datagrams equal to want.
+func countEqual(got []string, want string) int {
+	n := 0
+	for _, d := range got {
+		if d == want {
+			n++
+		}
+	}
+
+	return n
+}
+
+// fastConfig is a starting point for tests that just need a registry which
+// settles quickly. Tests with their own timing requirements override it.
+func fastConfig() health.Config {
+	return health.Config{
+		Interval:      10 * time.Millisecond,
+		Timeout:       5 * time.Millisecond,
+		FailThreshold: 1,
+		MinUnready:    time.Millisecond,
+		StaleAfter:    500 * time.Millisecond,
+		DrainHold:     time.Millisecond,
+	}
+}
+
+func stopAtCleanup(t *testing.T, reg *health.Registry) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		if err := reg.Stop(ctx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+}
+
+// newTestRegistry returns a started registry, stopped again at cleanup. The
+// config is a parameter because the watchdog tests need a shorter StaleAfter.
+func newTestRegistry(t *testing.T, cfg health.Config) *health.Registry {
+	t.Helper()
+
+	reg := health.New(cfg, nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	stopAtCleanup(t, reg)
+
+	return reg
+}
+
+// newNotifier sets NOTIFY_SOCKET, builds a Notifier and stops it at cleanup.
+// The environment must be set before New, which reads it once.
+func newNotifier(t *testing.T, reg *health.Registry, addr string, opts ...Option) *Notifier {
+	t.Helper()
+
+	t.Setenv("NOTIFY_SOCKET", addr)
+
+	n := New(reg, opts...)
+	if n == nil {
+		t.Fatal("New returned nil with NOTIFY_SOCKET set")
+	}
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		if err := n.Stop(ctx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+
+	return n
+}
+
+// waitState polls until the registry reports want. Never sleep a fixed
+// duration waiting for a state: -race -count=3 turns that into a flake.
+func waitState(t *testing.T, reg *health.Registry, want health.State) {
+	t.Helper()
+
+	var got health.State
+	for range 2000 {
+		got = reg.Snapshot().State
+		if got == want {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("state = %s, want %s", got, want)
+}
+
+// waitFor polls cond for up to two seconds.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	for range 2000 {
+		if cond() {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func failing(name string) health.Check {
+	return func(context.Context) error { return errors.New(name + " is down") }
+}
+
+func passing(context.Context) error { return nil }
+
+// toggle is a check a test can flip without racing the registry's goroutines.
+type toggle struct {
+	down atomic.Bool
+	err  error
+}
+
+func newToggle(err error) *toggle {
+	return &toggle{err: err}
+}
+
+func (tg *toggle) check(context.Context) error {
+	if tg.down.Load() {
+		return tg.err
+	}
+
+	return nil
+}
+
+func (tg *toggle) fail() { tg.down.Store(true) }
+
+func (tg *toggle) pass() { tg.down.Store(false) }
+
+// logCapture collects records so a test can assert on what was logged. The
+// mutex is genuinely needed and test-only: records are appended from the loop
+// goroutine and read by the test.
+type logCapture struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (c *logCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.records = append(c.records, r.Clone())
+
+	return nil
+}
+
+func (c *logCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+
+func (c *logCapture) WithGroup(string) slog.Handler { return c }
+
+func (c *logCapture) logger() *slog.Logger { return slog.New(c) }
+
+// errs returns every attribute named err whose value is an error.
+func (c *logCapture) errs() []error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var out []error
+	for _, r := range c.records {
+		r.Attrs(func(a slog.Attr) bool {
+			if err, ok := a.Value.Resolve().Any().(error); ok && a.Key == "err" {
+				out = append(out, err)
+			}
+
+			return true
+		})
+	}
+
+	return out
+}
+
+// text returns every message and attribute flattened.
+func (c *logCapture) text() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var b strings.Builder
+	for _, r := range c.records {
+		b.WriteString(r.Message)
+		r.Attrs(func(a slog.Attr) bool {
+			fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+
+			return true
+		})
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/infra/health/sdnotify/notifier.go
+++ b/infra/health/sdnotify/notifier.go
@@ -1,0 +1,239 @@
+package sdnotify
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// Notifier reports the registry's state to systemd. A nil *Notifier is a no-op.
+type Notifier struct {
+	reg  *health.Registry
+	addr string
+	log  *slog.Logger
+
+	writeTimeout time.Duration
+	poll         time.Duration
+	wdPeriod     time.Duration // WATCHDOG_USEC/2, 0 when disabled
+	startTimeout time.Duration
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopErr   error // written under stopOnce, so every caller sees the same verdict
+}
+
+// loopState lives on the loop goroutine's stack, so it needs no mutex.
+type loopState struct {
+	readySent  bool
+	haveStatus bool
+	lastState  health.State
+}
+
+// New builds a Notifier, or nil when NOTIFY_SOCKET is unset. The environment is
+// read once, here.
+func New(r *health.Registry, opts ...Option) *Notifier {
+	addr := os.Getenv("NOTIFY_SOCKET")
+	if addr == "" {
+		return nil
+	}
+
+	o := newOptions(opts)
+
+	// A malformed watchdog environment disables the ping and nothing else.
+	interval, err := watchdogEnabled()
+	if err != nil {
+		o.log.Warn("health/sdnotify: the watchdog environment is unusable, pings are disabled", "err", err)
+	}
+
+	return &Notifier{
+		reg:          r,
+		addr:         addr,
+		log:          o.log,
+		writeTimeout: o.writeTimeout,
+		poll:         o.poll,
+		wdPeriod:     interval / 2,
+		startTimeout: o.startTimeout,
+	}
+}
+
+// Start begins notifying. It does not block and a second call is a no-op. The
+// error is always nil — sd_notify(3) says to ignore notify failures — and the
+// signature keeps symmetry with health.Registry.Start.
+func (n *Notifier) Start(ctx context.Context) error {
+	if n == nil {
+		return nil
+	}
+
+	first := false
+	n.startOnce.Do(func() {
+		first = true
+		ctx, n.cancel = context.WithCancel(ctx)
+		n.done = make(chan struct{})
+
+		go n.loop(ctx)
+	})
+
+	if !first {
+		n.log.Debug("health/sdnotify: already started")
+	}
+
+	return nil
+}
+
+// Stop sends STOPPING=1 and halts the loop. Only the loop wait is bounded by
+// ctx; the STOPPING=1 write happens first regardless, bounded by
+// WithWriteTimeout — budget it on top of ctx. A second call repeats the first
+// verdict. It does not Drain: the consumer Drains first, then Stops.
+func (n *Notifier) Stop(ctx context.Context) error {
+	if n == nil {
+		return nil
+	}
+
+	n.stopOnce.Do(func() {
+		// Burning the start once makes a Start after Stop a no-op, and orders a
+		// concurrent Start against this Stop: sync.Once supplies the
+		// happens-before edge that lets cancel and done be read without a mutex.
+		n.startOnce.Do(func() {})
+
+		// Before the cancel, so a signal handler with a dead ctx still notifies.
+		// A poll tick racing this can emit one more STATUS=, byte-identical to
+		// this one, because the consumer has already Drained.
+		n.send(notifyStopping + "\nSTATUS=" + health.NameStopping)
+
+		if n.cancel == nil {
+			return // Start was never called
+		}
+
+		n.cancel()
+		n.stopErr = n.join(ctx)
+	})
+
+	return n.stopErr
+}
+
+// loop is the only goroutine; each of its three timers is a distinct trigger.
+func (n *Notifier) loop(ctx context.Context) {
+	defer close(n.done)
+
+	var ls loopState
+
+	poll := time.NewTicker(n.poll)
+	defer poll.Stop()
+
+	// A nil channel blocks forever in select, which is exactly "disabled".
+	var wdC <-chan time.Time
+	if n.wdPeriod > 0 {
+		wd := time.NewTicker(n.wdPeriod)
+		defer wd.Stop()
+		wdC = wd.C
+	}
+
+	var startC <-chan time.Time
+	if n.startTimeout > 0 {
+		st := time.NewTimer(n.startTimeout)
+		defer st.Stop()
+		startC = st.C
+	}
+
+	// Announcing readiness on an already-dead context is a lie to systemd.
+	if ctx.Err() != nil {
+		return
+	}
+
+	n.sync(&ls, n.reg.Snapshot())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-poll.C:
+			n.sync(&ls, n.reg.Snapshot())
+		case <-wdC:
+			n.ping()
+		case <-startC:
+			n.forceReady(&ls)
+		}
+	}
+}
+
+// sync emits READY=1 once and STATUS= on a state change, from the one snapshot
+// it is given — a second Snapshot() could straddle a change and pair the two
+// from different instants. State.Ready() is the trigger, as in ReadyFunc.
+func (n *Notifier) sync(ls *loopState, s health.Snapshot) {
+	text := statusText(s)
+
+	if !ls.readySent && s.State.Ready() {
+		n.send(notifyReady + "\nSTATUS=" + text)
+		ls.readySent, ls.haveStatus, ls.lastState = true, true, s.State
+
+		return
+	}
+
+	// haveStatus, not a zero lastState: State(0) is the real value StateUnknown.
+	if !ls.haveStatus || s.State != ls.lastState {
+		n.send("STATUS=" + text)
+		ls.haveStatus, ls.lastState = true, s.State
+	}
+}
+
+// ping proves the process is not wedged. SchedulerAlive is the sole gate, so a
+// dependency outage degrades readiness without restarting the whole fleet.
+func (n *Notifier) ping() {
+	if !n.reg.Snapshot().SchedulerAlive {
+		n.log.Debug("health/sdnotify: skipping the watchdog ping, the scheduler is not turning")
+
+		return
+	}
+
+	n.send(notifyWatchdog)
+}
+
+// forceReady is the WithStartTimeout fallback: better to come up visibly degraded
+// than hang in activating. Clearing haveStatus makes the next poll restate the truth.
+func (n *Notifier) forceReady(ls *loopState) {
+	if ls.readySent {
+		return
+	}
+
+	n.send(notifyReady + "\nSTATUS=" + statusStarting)
+	ls.readySent, ls.haveStatus = true, false
+}
+
+// send writes one datagram, dialling afresh. Failures are logged and swallowed:
+// the next tick retries, and a genuinely broken socket means systemd kills us
+// anyway, which is the correct outcome.
+func (n *Notifier) send(state string) {
+	if err := notify(n.addr, state, n.writeTimeout); err != nil {
+		n.log.Warn("health/sdnotify: sending a notification failed", "err", err, "state", state)
+	}
+}
+
+// join waits for the loop goroutine, bounded by ctx.
+func (n *Notifier) join(ctx context.Context) error {
+	// A non-blocking first look: with both ready, select picks at random, and an
+	// already-exited loop is never a failure.
+	select {
+	case <-n.done:
+		n.log.Info("health/sdnotify: stopped")
+
+		return nil
+	default:
+	}
+
+	select {
+	case <-n.done:
+		n.log.Info("health/sdnotify: stopped")
+
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("health/sdnotify: stopped with the loop still running: %w", ctx.Err())
+	}
+}

--- a/infra/health/sdnotify/notifier.go
+++ b/infra/health/sdnotify/notifier.go
@@ -37,8 +37,7 @@ type loopState struct {
 	lastState  health.State
 }
 
-// New builds a Notifier, or nil when NOTIFY_SOCKET is unset. The environment is
-// read once, here.
+// New builds a Notifier, or nil when NOTIFY_SOCKET is unset.
 func New(r *health.Registry, opts ...Option) *Notifier {
 	addr := os.Getenv("NOTIFY_SOCKET")
 	if addr == "" {
@@ -65,8 +64,7 @@ func New(r *health.Registry, opts ...Option) *Notifier {
 }
 
 // Start begins notifying. It does not block and a second call is a no-op. The
-// error is always nil — sd_notify(3) says to ignore notify failures — and the
-// signature keeps symmetry with health.Registry.Start.
+// error is always nil: sd_notify(3) says to ignore notify failures.
 func (n *Notifier) Start(ctx context.Context) error {
 	if n == nil {
 		return nil
@@ -89,23 +87,17 @@ func (n *Notifier) Start(ctx context.Context) error {
 }
 
 // Stop sends STOPPING=1 and halts the loop. Only the loop wait is bounded by
-// ctx; the STOPPING=1 write happens first regardless, bounded by
-// WithWriteTimeout — budget it on top of ctx. A second call repeats the first
-// verdict. It does not Drain: the consumer Drains first, then Stops.
+// ctx. It does not Drain: the consumer Drains first, then Stops.
 func (n *Notifier) Stop(ctx context.Context) error {
 	if n == nil {
 		return nil
 	}
 
 	n.stopOnce.Do(func() {
-		// Burning the start once makes a Start after Stop a no-op, and orders a
-		// concurrent Start against this Stop: sync.Once supplies the
-		// happens-before edge that lets cancel and done be read without a mutex.
+		// Burning the start once orders a concurrent Start against this Stop.
 		n.startOnce.Do(func() {})
 
 		// Before the cancel, so a signal handler with a dead ctx still notifies.
-		// A poll tick racing this can emit one more STATUS=, byte-identical to
-		// this one, because the consumer has already Drained.
 		n.send(notifyStopping + "\nSTATUS=" + health.NameStopping)
 
 		if n.cancel == nil {
@@ -119,7 +111,7 @@ func (n *Notifier) Stop(ctx context.Context) error {
 	return n.stopErr
 }
 
-// loop is the only goroutine; each of its three timers is a distinct trigger.
+// loop is the only goroutine.
 func (n *Notifier) loop(ctx context.Context) {
 	defer close(n.done)
 
@@ -128,7 +120,7 @@ func (n *Notifier) loop(ctx context.Context) {
 	poll := time.NewTicker(n.poll)
 	defer poll.Stop()
 
-	// A nil channel blocks forever in select, which is exactly "disabled".
+	// A nil channel blocks forever in select: that is "disabled".
 	var wdC <-chan time.Time
 	if n.wdPeriod > 0 {
 		wd := time.NewTicker(n.wdPeriod)
@@ -143,7 +135,6 @@ func (n *Notifier) loop(ctx context.Context) {
 		startC = st.C
 	}
 
-	// Announcing readiness on an already-dead context is a lie to systemd.
 	if ctx.Err() != nil {
 		return
 	}
@@ -165,8 +156,7 @@ func (n *Notifier) loop(ctx context.Context) {
 }
 
 // sync emits READY=1 once and STATUS= on a state change, from the one snapshot
-// it is given — a second Snapshot() could straddle a change and pair the two
-// from different instants. State.Ready() is the trigger, as in ReadyFunc.
+// it is given.
 func (n *Notifier) sync(ls *loopState, s health.Snapshot) {
 	text := statusText(s)
 
@@ -177,7 +167,7 @@ func (n *Notifier) sync(ls *loopState, s health.Snapshot) {
 		return
 	}
 
-	// haveStatus, not a zero lastState: State(0) is the real value StateUnknown.
+	// haveStatus, not a zero lastState: State(0) is a real value.
 	if !ls.haveStatus || s.State != ls.lastState {
 		n.send("STATUS=" + text)
 		ls.haveStatus, ls.lastState = true, s.State
@@ -185,7 +175,7 @@ func (n *Notifier) sync(ls *loopState, s health.Snapshot) {
 }
 
 // ping proves the process is not wedged. SchedulerAlive is the sole gate, so a
-// dependency outage degrades readiness without restarting the whole fleet.
+// dependency outage cannot restart the fleet.
 func (n *Notifier) ping() {
 	if !n.reg.Snapshot().SchedulerAlive {
 		n.log.Debug("health/sdnotify: skipping the watchdog ping, the scheduler is not turning")
@@ -196,8 +186,8 @@ func (n *Notifier) ping() {
 	n.send(notifyWatchdog)
 }
 
-// forceReady is the WithStartTimeout fallback: better to come up visibly degraded
-// than hang in activating. Clearing haveStatus makes the next poll restate the truth.
+// forceReady is the WithStartTimeout fallback. Clearing haveStatus makes the
+// next poll restate the truth.
 func (n *Notifier) forceReady(ls *loopState) {
 	if ls.readySent {
 		return
@@ -207,9 +197,7 @@ func (n *Notifier) forceReady(ls *loopState) {
 	ls.readySent, ls.haveStatus = true, false
 }
 
-// send writes one datagram, dialling afresh. Failures are logged and swallowed:
-// the next tick retries, and a genuinely broken socket means systemd kills us
-// anyway, which is the correct outcome.
+// send writes one datagram, dialling afresh. Failures are logged, not returned.
 func (n *Notifier) send(state string) {
 	if err := notify(n.addr, state, n.writeTimeout); err != nil {
 		n.log.Warn("health/sdnotify: sending a notification failed", "err", err, "state", state)
@@ -218,8 +206,7 @@ func (n *Notifier) send(state string) {
 
 // join waits for the loop goroutine, bounded by ctx.
 func (n *Notifier) join(ctx context.Context) error {
-	// A non-blocking first look: with both ready, select picks at random, and an
-	// already-exited loop is never a failure.
+	// A non-blocking first look: an already-exited loop is never a failure.
 	select {
 	case <-n.done:
 		n.log.Info("health/sdnotify: stopped")

--- a/infra/health/sdnotify/notifier_test.go
+++ b/infra/health/sdnotify/notifier_test.go
@@ -378,6 +378,10 @@ func TestStartTimeoutFallbackRestatesTruth(t *testing.T) {
 	}
 
 	got := recvAll(t, ln, 200*time.Millisecond, 3*time.Second)
+	if len(got) == 0 {
+		t.Fatal("no datagrams arrived")
+	}
+
 	want := "STATUS=" + health.NameNotReady + ": failing [db]"
 	if last := got[len(got)-1]; last != want {
 		t.Fatalf("last datagram = %q, want %q; got %q", last, want, got)

--- a/infra/health/sdnotify/notifier_test.go
+++ b/infra/health/sdnotify/notifier_test.go
@@ -1,0 +1,480 @@
+package sdnotify
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+func TestNewWithoutSocket(t *testing.T) {
+	// Explicit rather than ambient: a CI runner that set NOTIFY_SOCKET would
+	// otherwise break this silently.
+	t.Setenv("NOTIFY_SOCKET", "")
+
+	n := New(health.New(fastConfig(), nil))
+	if n != nil {
+		t.Fatal("New returned a Notifier with NOTIFY_SOCKET unset")
+	}
+
+	ctx := context.Background()
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("Start on a nil Notifier: %v", err)
+	}
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("Stop on a nil Notifier: %v", err)
+	}
+}
+
+func TestReadyAndStopEndToEnd(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+
+	ctx := context.Background()
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if got, want := recv(t, ln, time.Second), notifyReady+"\nSTATUS="+health.NameReady; got != want {
+		t.Fatalf("ready datagram = %q, want %q", got, want)
+	}
+
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if got, want := recv(t, ln, time.Second), notifyStopping+"\nSTATUS="+health.NameStopping; got != want {
+		t.Fatalf("stop datagram = %q, want %q", got, want)
+	}
+}
+
+func TestReadySentOnceOnReady(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := recvAll(t, ln, 50*time.Millisecond, 2*time.Second)
+
+	ready := 0
+	for _, d := range got {
+		if strings.Contains(d, notifyReady) {
+			ready++
+		}
+	}
+	if ready != 1 {
+		t.Fatalf("READY=1 datagrams = %d, want 1; got %q", ready, got)
+	}
+}
+
+func TestReadyOnDegraded(t *testing.T) {
+	// Degraded means every critical check is green, which is literally the
+	// design's own READY=1 trigger. ReadyFunc and /readyz already agree.
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	reg.Informational("s3", failing("s3"))
+	waitState(t, reg, health.StateDegraded)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	want := notifyReady + "\nSTATUS=" + health.NameDegraded + ": informational [s3]"
+	if got := recv(t, ln, time.Second); got != want {
+		t.Fatalf("datagram = %q, want %q", got, want)
+	}
+}
+
+func TestNoReadyBeforeFirstRound(t *testing.T) {
+	// A check that has not finished its first run: the cold start, where every
+	// counting check is unknown and there is no verdict to report yet.
+	addr, ln := notifySocket(t)
+
+	cfg := fastConfig()
+	cfg.Interval = time.Second
+	cfg.Timeout = 900 * time.Millisecond
+
+	reg := newTestRegistry(t, cfg)
+	reg.Critical("db", func(ctx context.Context) error {
+		<-ctx.Done()
+
+		return ctx.Err()
+	})
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := recvAll(t, ln, 50*time.Millisecond, 2*time.Second)
+	if len(got) == 0 {
+		t.Fatal("no STATUS= datagram at all")
+	}
+	for _, d := range got {
+		if strings.Contains(d, notifyReady) {
+			t.Fatalf("READY=1 before the first round: %q", got)
+		}
+	}
+}
+
+func TestStatusOnChange(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	tg := newToggle(errors.New("db is down"))
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", tg.check)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if got, want := recv(t, ln, time.Second), notifyReady+"\nSTATUS="+health.NameReady; got != want {
+		t.Fatalf("ready datagram = %q, want %q", got, want)
+	}
+	if quiet := recvAll(t, ln, 50*time.Millisecond, 2*time.Second); len(quiet) != 0 {
+		t.Fatalf("steady state sent %q, want nothing", quiet)
+	}
+
+	tg.fail()
+	waitState(t, reg, health.StateNotReady)
+
+	want := "STATUS=" + health.NameNotReady + ": failing [db]"
+	if got := recv(t, ln, time.Second); got != want {
+		t.Fatalf("change datagram = %q, want %q", got, want)
+	}
+	if quiet := recvAll(t, ln, 50*time.Millisecond, 2*time.Second); len(quiet) != 0 {
+		t.Fatalf("steady state sent %q, want nothing", quiet)
+	}
+}
+
+func TestRedialAfterRebind(t *testing.T) {
+	// The executable form of "no conn field on Notifier": a cached unixgram
+	// conn is permanently dead once the receiver re-binds, while a fresh dial
+	// per message recovers with no reconnect code at all.
+	addr, ln := notifySocket(t)
+
+	tg := newToggle(errors.New("db is down"))
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", tg.check)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	recv(t, ln, time.Second) // READY=1
+
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ln2 := rebind(t, addr)
+
+	tg.fail()
+	waitState(t, reg, health.StateNotReady)
+
+	want := "STATUS=" + health.NameNotReady + ": failing [db]"
+	if got := recv(t, ln2, 2*time.Second); got != want {
+		t.Fatalf("datagram after the rebind = %q, want %q", got, want)
+	}
+}
+
+func TestWriteDeadline(t *testing.T) {
+	// This exercises the deadline plumbing, not real backpressure: on darwin an
+	// undrained unixgram receiver returns ENOBUFS immediately rather than
+	// blocking, so a backpressure test would pass on Linux and fail here.
+	addr, _ := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	lg := &logCapture{}
+	n := newNotifier(t, reg, addr,
+		WithPollInterval(10*time.Millisecond),
+		WithWriteTimeout(time.Nanosecond),
+		WithLogger(lg.logger()))
+
+	ctx := context.Background()
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	waitFor(t, "a deadline error to be logged", func() bool {
+		for _, err := range lg.errs() {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				return true
+			}
+		}
+
+		return false
+	})
+
+	// A notify failure is never fatal.
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestLifecycleEdges(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+
+	ctx := context.Background()
+
+	// Stop before Start still tells systemd we are going away.
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("Stop before Start: %v", err)
+	}
+	if got, want := recv(t, ln, time.Second), notifyStopping+"\nSTATUS="+health.NameStopping; got != want {
+		t.Fatalf("stop datagram = %q, want %q", got, want)
+	}
+
+	// The burnt startOnce makes every later Start a no-op.
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("Start after Stop: %v", err)
+	}
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+	if got := recvAll(t, ln, 50*time.Millisecond, 2*time.Second); len(got) != 0 {
+		t.Fatalf("a no-op Start sent %q, want nothing", got)
+	}
+
+	// Registry.Snapshot is nil-safe, so a nil registry must not panic.
+	t.Setenv("NOTIFY_SOCKET", addr)
+
+	empty := New(nil, WithPollInterval(10*time.Millisecond))
+	if empty == nil {
+		t.Fatal("New returned nil with NOTIFY_SOCKET set")
+	}
+	if err := empty.Start(ctx); err != nil {
+		t.Fatalf("Start with a nil registry: %v", err)
+	}
+	if err := empty.Stop(ctx); err != nil {
+		t.Fatalf("Stop with a nil registry: %v", err)
+	}
+}
+
+func TestAbstractSocket(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("abstract unix sockets are Linux-only; on darwin '@' is an ordinary filename")
+	}
+
+	// This is the one socket test that does not go through notifySocket, so it
+	// neutralises the ambient watchdog environment itself.
+	t.Setenv("WATCHDOG_USEC", "")
+	t.Setenv("WATCHDOG_PID", "")
+
+	// A bare PID is not enough: -count=3 runs three iterations in one process.
+	name := "@webitel-health-" + strconv.Itoa(os.Getpid()) + "-" +
+		strconv.FormatUint(socketNonce.Add(1), 10)
+
+	ln, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: name, Net: "unixgram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, name, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if got, want := recv(t, ln, time.Second), notifyReady+"\nSTATUS="+health.NameReady; got != want {
+		t.Fatalf("datagram = %q, want %q", got, want)
+	}
+}
+
+func TestStartTimeoutFallback(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	tg := newToggle(errors.New("db is down"))
+	tg.fail()
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", tg.check)
+	waitState(t, reg, health.StateNotReady)
+
+	n := newNotifier(t, reg, addr,
+		WithPollInterval(10*time.Millisecond),
+		WithStartTimeout(20*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	fallback := notifyReady + "\nSTATUS=" + statusStarting
+	got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	if c := countEqual(got, fallback); c != 1 {
+		t.Fatalf("fallback datagrams = %d, want 1; got %q", c, got)
+	}
+
+	// Becoming genuinely ready afterwards reports STATUS=ready with no second
+	// READY=1.
+	tg.pass()
+	waitState(t, reg, health.StateReady)
+
+	rest := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	for _, d := range rest {
+		if strings.Contains(d, notifyReady) {
+			t.Fatalf("a second READY=1 after the fallback: %q", rest)
+		}
+	}
+	if want := "STATUS=" + health.NameReady; countEqual(rest, want) != 1 {
+		t.Fatalf("datagrams = %q, want exactly one %q", rest, want)
+	}
+}
+
+func TestStartTimeoutFallbackRestatesTruth(t *testing.T) {
+	// The wedged node the fallback exists for: the state never changes again,
+	// so "starting degraded" must not be the last thing systemd ever hears.
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", failing("db"))
+	waitState(t, reg, health.StateNotReady)
+
+	n := newNotifier(t, reg, addr,
+		WithPollInterval(10*time.Millisecond),
+		WithStartTimeout(30*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := recvAll(t, ln, 200*time.Millisecond, 3*time.Second)
+	want := "STATUS=" + health.NameNotReady + ": failing [db]"
+	if last := got[len(got)-1]; last != want {
+		t.Fatalf("last datagram = %q, want %q; got %q", last, want, got)
+	}
+}
+
+func TestStartOnADeadContextSendsNothing(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second); len(got) != 0 {
+		t.Fatalf("Start on a dead ctx announced %q, want nothing", got)
+	}
+}
+
+func TestStopAfterTheLoopExitedIsNotAnError(t *testing.T) {
+	// Both done and ctx.Done are ready here, and select picks at random: a loop
+	// that has provably already exited must never be reported as still running.
+	addr, _ := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := n.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cancel()
+	<-n.done
+
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("Stop after the loop exited: %v", err)
+	}
+}
+
+func TestStopRepeatsTheFirstVerdict(t *testing.T) {
+	// A second caller blocks inside stopOnce and must not report success when
+	// the first caller left the loop running.
+	addr, _ := notifySocket(t)
+
+	t.Setenv("NOTIFY_SOCKET", addr)
+
+	n := New(nil)
+	if n == nil {
+		t.Fatal("New returned nil with NOTIFY_SOCKET set")
+	}
+
+	// Stand in for a loop that will not exit: done never closes, so join can
+	// only report the ctx deadline.
+	n.cancel, n.done = func() {}, make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	first := n.Stop(ctx)
+	if first == nil {
+		t.Fatal("Stop with a live loop and a dead ctx returned nil")
+	}
+	if second := n.Stop(ctx); second == nil {
+		t.Fatalf("a second Stop returned nil, want %v", first)
+	}
+}
+
+func TestStartTimeoutDisabled(t *testing.T) {
+	// The fallback really does ship off: without the option there is none.
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", failing("db"))
+	waitState(t, reg, health.StateNotReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	if len(got) == 0 {
+		t.Fatal("no STATUS= datagram at all")
+	}
+	for _, d := range got {
+		if strings.Contains(d, notifyReady) {
+			t.Fatalf("READY=1 with WithStartTimeout unset: %q", got)
+		}
+	}
+}

--- a/infra/health/sdnotify/options.go
+++ b/infra/health/sdnotify/options.go
@@ -26,8 +26,7 @@ func WithLogger(log *slog.Logger) Option {
 	}
 }
 
-// WithWriteTimeout bounds one datagram write; the default is a second. A
-// non-positive d is ignored.
+// WithWriteTimeout bounds one datagram write. Default a second; non-positive is ignored.
 func WithWriteTimeout(d time.Duration) Option {
 	return func(o *options) {
 		if d <= 0 {
@@ -38,8 +37,8 @@ func WithWriteTimeout(d time.Duration) Option {
 	}
 }
 
-// WithPollInterval sets how often the registry is read for a state change; the
-// default is a second. A non-positive d is ignored.
+// WithPollInterval sets how often the registry is read. Default a second;
+// non-positive is ignored.
 func WithPollInterval(d time.Duration) Option {
 	return func(o *options) {
 		if d <= 0 {
@@ -51,14 +50,8 @@ func WithPollInterval(d time.Duration) Option {
 }
 
 // WithStartTimeout sends READY=1 with STATUS=starting degraded when readiness
-// has not arrived within d, so a unit does not hang in activating over one red
-// check. It is off by default, and a non-positive d leaves it off.
-//
-// The fallback only matters under Type=notify, so flipping Type=notify, setting
-// TimeoutStartSec=90 and passing this option are three changes that belong in
-// one commit — WTEL-10090's. Keep d comfortably below the unit's
-// TimeoutStartSec (60s against the design's 90s), or systemd kills the unit
-// before the fallback can fire.
+// has not arrived within d, so a unit does not hang in activating. Off by
+// default. Keep d below the unit's TimeoutStartSec.
 func WithStartTimeout(d time.Duration) Option {
 	return func(o *options) {
 		if d <= 0 {
@@ -70,7 +63,7 @@ func WithStartTimeout(d time.Duration) Option {
 }
 
 // newOptions applies opts over a discarding logger: a library must not write to
-// stderr uninvited, so the default is never slog.Default.
+// stderr uninvited.
 func newOptions(opts []Option) options {
 	o := options{
 		log:          slog.New(slog.DiscardHandler),

--- a/infra/health/sdnotify/options.go
+++ b/infra/health/sdnotify/options.go
@@ -1,0 +1,85 @@
+package sdnotify
+
+import (
+	"log/slog"
+	"time"
+)
+
+// Option configures a Notifier.
+type Option func(*options)
+
+type options struct {
+	log          *slog.Logger
+	writeTimeout time.Duration
+	poll         time.Duration
+	startTimeout time.Duration
+}
+
+// WithLogger sets the logger. A nil logger is ignored.
+func WithLogger(log *slog.Logger) Option {
+	return func(o *options) {
+		if log == nil {
+			return
+		}
+
+		o.log = log
+	}
+}
+
+// WithWriteTimeout bounds one datagram write; the default is a second. A
+// non-positive d is ignored.
+func WithWriteTimeout(d time.Duration) Option {
+	return func(o *options) {
+		if d <= 0 {
+			return
+		}
+
+		o.writeTimeout = d
+	}
+}
+
+// WithPollInterval sets how often the registry is read for a state change; the
+// default is a second. A non-positive d is ignored.
+func WithPollInterval(d time.Duration) Option {
+	return func(o *options) {
+		if d <= 0 {
+			return
+		}
+
+		o.poll = d
+	}
+}
+
+// WithStartTimeout sends READY=1 with STATUS=starting degraded when readiness
+// has not arrived within d, so a unit does not hang in activating over one red
+// check. It is off by default, and a non-positive d leaves it off.
+//
+// The fallback only matters under Type=notify, so flipping Type=notify, setting
+// TimeoutStartSec=90 and passing this option are three changes that belong in
+// one commit — WTEL-10090's. Keep d comfortably below the unit's
+// TimeoutStartSec (60s against the design's 90s), or systemd kills the unit
+// before the fallback can fire.
+func WithStartTimeout(d time.Duration) Option {
+	return func(o *options) {
+		if d <= 0 {
+			return
+		}
+
+		o.startTimeout = d
+	}
+}
+
+// newOptions applies opts over a discarding logger: a library must not write to
+// stderr uninvited, so the default is never slog.Default.
+func newOptions(opts []Option) options {
+	o := options{
+		log:          slog.New(slog.DiscardHandler),
+		writeTimeout: time.Second,
+		poll:         time.Second,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return o
+}

--- a/infra/health/sdnotify/race_test.go
+++ b/infra/health/sdnotify/race_test.go
@@ -1,0 +1,266 @@
+package sdnotify
+
+import (
+	"context"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// Run under -race. Most of these assert only "no race, no panic, no deadlock,
+// no leak" — the detector and the test timeout are the assertions.
+
+func goroutinesSettled(t *testing.T, want int) int {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	got := runtime.NumGoroutine()
+	for time.Now().Before(deadline) {
+		got = runtime.NumGoroutine()
+		if got <= want {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	return got
+}
+
+func TestRaceConcurrentStartAndStop(t *testing.T) {
+	// A signal handler racing the startup path. Both sync.Once uses have to
+	// order this without a mutex.
+	for round := 0; round < 15; round++ {
+		addr, _ := notifySocket(t)
+		reg := newTestRegistry(t, fastConfig())
+		reg.Critical("db", func(context.Context) error { return nil })
+		n := newNotifier(t, reg, addr)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+
+				if i%2 == 0 {
+					_ = n.Start(ctx)
+
+					return
+				}
+				_ = n.Stop(ctx)
+			}(i)
+		}
+		wg.Wait()
+	}
+}
+
+func TestRaceRepeatedStopReturnsTheSameVerdict(t *testing.T) {
+	addr, _ := notifySocket(t)
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", func(context.Context) error { return nil })
+	n := newNotifier(t, reg, addr)
+
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var mu sync.Mutex
+	seen := map[string]int{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			err := n.Stop(ctx)
+			key := "nil"
+			if err != nil {
+				key = err.Error()
+			}
+			mu.Lock()
+			seen[key]++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(seen) != 1 {
+		t.Fatalf("concurrent Stops disagreed: %v", seen)
+	}
+}
+
+func TestRaceNotifierCyclesDoNotLeakGoroutines(t *testing.T) {
+	base := runtime.NumGoroutine()
+
+	for i := 0; i < 20; i++ {
+		addr, _ := notifySocket(t)
+
+		// Own the registry's lifecycle here rather than via newTestRegistry:
+		// its t.Cleanup fires at test end, so every iteration's checks would
+		// still be running and this test would measure them as a leak.
+		reg := health.New(fastConfig(), nil)
+		reg.Critical("db", func(context.Context) error { return nil })
+		if err := reg.Start(context.Background()); err != nil {
+			t.Fatalf("cycle %d: registry Start: %v", i, err)
+		}
+
+		t.Setenv("NOTIFY_SOCKET", addr)
+		n := New(reg)
+		if n == nil {
+			t.Fatal("New returned nil with NOTIFY_SOCKET set")
+		}
+		if err := n.Start(context.Background()); err != nil {
+			t.Fatalf("cycle %d: Start: %v", i, err)
+		}
+		time.Sleep(2 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := n.Stop(ctx); err != nil {
+			t.Fatalf("cycle %d: Stop: %v", i, err)
+		}
+		if err := reg.Stop(ctx); err != nil {
+			t.Fatalf("cycle %d: registry Stop: %v", i, err)
+		}
+		cancel()
+	}
+
+	if got := goroutinesSettled(t, base+4); got > base+4 {
+		t.Fatalf("goroutines %d -> %d after 20 notifier cycles", base, got)
+	}
+}
+
+func TestRaceParentContextCancelRacesStop(t *testing.T) {
+	base := runtime.NumGoroutine()
+
+	for i := 0; i < 15; i++ {
+		addr, _ := notifySocket(t)
+
+		// Own the registry's lifecycle here — see the note in the cycles test.
+		reg := health.New(fastConfig(), nil)
+		reg.Critical("db", func(context.Context) error { return nil })
+		if err := reg.Start(context.Background()); err != nil {
+			t.Fatalf("registry Start: %v", err)
+		}
+
+		t.Setenv("NOTIFY_SOCKET", addr)
+		n := New(reg)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		if err := n.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); cancel() }()
+		go func() {
+			defer wg.Done()
+			sctx, scancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer scancel()
+			n.Stop(sctx)
+		}()
+		wg.Wait()
+		cancel()
+
+		sctx, scancel := context.WithTimeout(context.Background(), 2*time.Second)
+		reg.Stop(sctx)
+		scancel()
+	}
+
+	if got := goroutinesSettled(t, base+4); got > base+4 {
+		t.Fatalf("goroutines %d -> %d after 15 cancel/stop races", base, got)
+	}
+}
+
+func TestRaceRegistryChurnsWhileTheNotifierRuns(t *testing.T) {
+	// Registration collides with the notifier's poll loop, which snapshots on
+	// every tick and sends on every state change.
+	addr, ln := notifySocket(t)
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", func(context.Context) error { return nil })
+
+	n := newNotifier(t, reg, addr, WithPollInterval(time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			reg.Informational("late"+strconv.Itoa(i), func(context.Context) error { return nil })
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	got := recvAll(t, ln, 50*time.Millisecond, 5*time.Second)
+	wg.Wait()
+
+	for _, d := range got {
+		if strings.Count(d, "STATUS=") > 1 {
+			t.Fatalf("a datagram carried two STATUS= lines: %q", d)
+		}
+		for _, line := range strings.Split(d, "\n") {
+			if len(line) > 1024+len("STATUS=") {
+				t.Fatalf("a line exceeded the cap: %d bytes", len(line))
+			}
+		}
+	}
+}
+
+func TestRaceNilNotifierUnderConcurrency(t *testing.T) {
+	// No NOTIFY_SOCKET: New returns nil and every method must stay a no-op.
+	t.Setenv("NOTIFY_SOCKET", "")
+
+	reg := newTestRegistry(t, fastConfig())
+	n := New(reg)
+	if n != nil {
+		t.Fatal("New returned non-nil without NOTIFY_SOCKET")
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := n.Start(context.Background()); err != nil {
+				panic("nil notifier Start: " + err.Error())
+			}
+			if err := n.Stop(context.Background()); err != nil {
+				panic("nil notifier Stop: " + err.Error())
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestNoReadyWithOnlyInformationalChecks is the sd_notify half of the spec
+// violation found in review: a registry holding only informational checks
+// announced READY=1 to systemd before any check had run.
+func TestNoReadyWithOnlyInformationalChecks(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := health.New(fastConfig(), nil)
+	reg.Informational("rabbit", func(context.Context) error { return nil })
+
+	n := newNotifier(t, reg, addr, WithPollInterval(time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	for _, d := range recvAll(t, ln, 40*time.Millisecond, 3*time.Second) {
+		if strings.Contains(d, "READY=1") {
+			t.Fatalf("systemd was told READY=1 with only informational checks: %q", d)
+		}
+	}
+}

--- a/infra/health/sdnotify/race_test.go
+++ b/infra/health/sdnotify/race_test.go
@@ -252,6 +252,23 @@ func TestNoReadyWithOnlyInformationalChecks(t *testing.T) {
 
 	reg := health.New(fastConfig(), nil)
 	reg.Informational("rabbit", func(context.Context) error { return nil })
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("registry Start: %v", err)
+	}
+	stopAtCleanup(t, reg)
+
+	// The registry must actually run the check first. Without this the state is
+	// unknown only because nothing has run, and the assertion below would hold
+	// for a critical check too — proving nothing about the informational rule.
+	waitFor(t, "the informational check to pass", func() bool {
+		for _, c := range reg.Snapshot().Checks {
+			if c.Name == "rabbit" && c.Status == health.StatusOK {
+				return true
+			}
+		}
+
+		return false
+	})
 
 	n := newNotifier(t, reg, addr, WithPollInterval(time.Millisecond))
 	if err := n.Start(context.Background()); err != nil {

--- a/infra/health/sdnotify/status.go
+++ b/infra/health/sdnotify/status.go
@@ -8,17 +8,14 @@ import (
 	"github.com/webitel/webitel-go-kit/infra/health"
 )
 
-// statusStarting is the WithStartTimeout fallback line, in the design's own
-// wording.
+// statusStarting is the WithStartTimeout fallback line.
 const statusStarting = "starting degraded"
 
 // maxStatusBytes caps the STATUS= line; see truncate.
 const maxStatusBytes = 1024
 
-// statusText renders the STATUS= line for one snapshot. It is the only place
-// that decides what STATUS= looks like.
-//
-// CheckResult.Err is never read here: check.go says it is for logs only.
+// statusText renders the STATUS= line. CheckResult.Err is never read here: it
+// is for logs only.
 func statusText(s health.Snapshot) string {
 	if s.State == health.StateStopping {
 		return health.NameStopping // a draining registry's check list is noise
@@ -27,13 +24,11 @@ func statusText(s health.Snapshot) string {
 		return health.NameUnknown + ": no checks registered"
 	}
 
-	// pending rather than unknown, so the line does not read "unknown: unknown".
+	// pending, so the line does not read "unknown: unknown".
 	var failing, pending, informational []string
 	for _, c := range s.Checks {
 		if c.Group == health.GroupInformational {
-			// Split the same way the counting groups are: an informational
-			// check that has never run is pending, not "informational [s3]",
-			// which an operator reads as "s3 is down".
+			// Never-run reads as pending, not as down.
 			if c.Status == health.StatusFail {
 				informational = append(informational, sanitize(c.Name))
 			}
@@ -68,10 +63,8 @@ func statusText(s health.Snapshot) string {
 	return truncate(s.State.String() + ": " + strings.Join(parts, "; "))
 }
 
-// truncate caps the line on a rune boundary. systemd's PID 1 drops an
-// oversized notify datagram whole, taking the READY=1 riding with it, so a
-// consumer registering enough checks would silently lose readiness rather than
-// merely lose the status text.
+// truncate caps the line on a rune boundary: systemd drops an oversized
+// datagram whole, taking any READY=1 riding with it.
 func truncate(s string) string {
 	if len(s) <= maxStatusBytes {
 		return s
@@ -87,8 +80,7 @@ func truncate(s string) string {
 	return s[:cut] + ell
 }
 
-// sanitize maps control characters to '_' so STATUS= is always one line: a
-// newline in a check name would otherwise be parsed as a second assignment.
+// sanitize maps control characters to '_' so STATUS= is always one line.
 func sanitize(name string) string {
 	return strings.Map(func(r rune) rune {
 		if r < 0x20 || r == 0x7f {

--- a/infra/health/sdnotify/status.go
+++ b/infra/health/sdnotify/status.go
@@ -1,0 +1,100 @@
+package sdnotify
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// statusStarting is the WithStartTimeout fallback line, in the design's own
+// wording.
+const statusStarting = "starting degraded"
+
+// maxStatusBytes caps the STATUS= line; see truncate.
+const maxStatusBytes = 1024
+
+// statusText renders the STATUS= line for one snapshot. It is the only place
+// that decides what STATUS= looks like.
+//
+// CheckResult.Err is never read here: check.go says it is for logs only.
+func statusText(s health.Snapshot) string {
+	if s.State == health.StateStopping {
+		return health.NameStopping // a draining registry's check list is noise
+	}
+	if len(s.Checks) == 0 {
+		return health.NameUnknown + ": no checks registered"
+	}
+
+	// pending rather than unknown, so the line does not read "unknown: unknown".
+	var failing, pending, informational []string
+	for _, c := range s.Checks {
+		if c.Group == health.GroupInformational {
+			// Split the same way the counting groups are: an informational
+			// check that has never run is pending, not "informational [s3]",
+			// which an operator reads as "s3 is down".
+			if c.Status == health.StatusFail {
+				informational = append(informational, sanitize(c.Name))
+			}
+			if c.Status == health.StatusUnknown {
+				pending = append(pending, sanitize(c.Name))
+			}
+
+			continue
+		}
+		if c.Status == health.StatusFail {
+			failing = append(failing, sanitize(c.Name))
+		}
+		if c.Status == health.StatusUnknown {
+			pending = append(pending, sanitize(c.Name))
+		}
+	}
+
+	var parts []string
+	if len(failing) > 0 {
+		parts = append(parts, fmt.Sprintf("failing [%s]", strings.Join(failing, " ")))
+	}
+	if len(pending) > 0 {
+		parts = append(parts, fmt.Sprintf("pending [%s]", strings.Join(pending, " ")))
+	}
+	if len(informational) > 0 {
+		parts = append(parts, fmt.Sprintf("informational [%s]", strings.Join(informational, " ")))
+	}
+	if len(parts) == 0 {
+		return truncate(s.State.String())
+	}
+
+	return truncate(s.State.String() + ": " + strings.Join(parts, "; "))
+}
+
+// truncate caps the line on a rune boundary. systemd's PID 1 drops an
+// oversized notify datagram whole, taking the READY=1 riding with it, so a
+// consumer registering enough checks would silently lose readiness rather than
+// merely lose the status text.
+func truncate(s string) string {
+	if len(s) <= maxStatusBytes {
+		return s
+	}
+
+	const ell = "..."
+
+	cut := maxStatusBytes - len(ell)
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+
+	return s[:cut] + ell
+}
+
+// sanitize maps control characters to '_' so STATUS= is always one line: a
+// newline in a check name would otherwise be parsed as a second assignment.
+func sanitize(name string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return '_'
+		}
+
+		return r
+	}, name)
+}

--- a/infra/health/sdnotify/status_test.go
+++ b/infra/health/sdnotify/status_test.go
@@ -1,0 +1,238 @@
+package sdnotify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+// sentinel is the check error text that must never reach a datagram.
+const sentinel = "SENTINEL-9f2a41-must-not-leak"
+
+func check(name string, group health.Group, status health.Status) health.CheckResult {
+	return health.CheckResult{Name: name, Group: group, Status: status}
+}
+
+func TestStatusTextTable(t *testing.T) {
+	cases := []struct {
+		name string
+		snap health.Snapshot
+		want string
+	}{
+		{
+			name: "ready",
+			snap: health.Snapshot{State: health.StateReady, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusOK),
+			}},
+			want: "ready",
+		},
+		{
+			name: "degraded",
+			snap: health.Snapshot{State: health.StateDegraded, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusOK),
+				check("s3", health.GroupInformational, health.StatusFail),
+			}},
+			want: "degraded: informational [s3]",
+		},
+		{
+			name: "not ready",
+			snap: health.Snapshot{State: health.StateNotReady, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusFail),
+			}},
+			want: "not_ready: failing [db]",
+		},
+		{
+			name: "not ready and informational",
+			snap: health.Snapshot{State: health.StateNotReady, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusFail),
+				check("s3", health.GroupInformational, health.StatusFail),
+			}},
+			want: "not_ready: failing [db]; informational [s3]",
+		},
+		{
+			name: "no checks",
+			snap: health.Snapshot{State: health.StateUnknown},
+			want: "unknown: no checks registered",
+		},
+		{
+			name: "pending",
+			snap: health.Snapshot{State: health.StateUnknown, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusUnknown),
+			}},
+			want: "unknown: pending [db]",
+		},
+		{
+			name: "informational pending",
+			snap: health.Snapshot{State: health.StateDegraded, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusOK),
+				check("s3", health.GroupInformational, health.StatusUnknown),
+			}},
+			want: "degraded: pending [s3]",
+		},
+		{
+			name: "stopping",
+			snap: health.Snapshot{State: health.StateStopping, Checks: []health.CheckResult{
+				check("db", health.GroupCritical, health.StatusFail),
+			}},
+			want: "stopping",
+		},
+	}
+
+	for _, c := range cases {
+		if got := statusText(c.snap); got != c.want {
+			t.Errorf("%s: statusText = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestStatusTextSanitisesNames(t *testing.T) {
+	s := health.Snapshot{State: health.StateNotReady, Checks: []health.CheckResult{
+		check("bad\nREADY=1\tx", health.GroupCritical, health.StatusFail),
+	}}
+
+	got := statusText(s)
+	if want := "not_ready: failing [bad_READY=1_x]"; got != want {
+		t.Fatalf("statusText = %q, want %q", got, want)
+	}
+	if strings.Count(got, "\n") != 0 {
+		t.Fatalf("statusText = %q, want a single line", got)
+	}
+}
+
+func TestStatusTextIsCapped(t *testing.T) {
+	// systemd drops an oversized datagram whole, taking the READY=1 riding with
+	// it. The names are multi-byte on purpose: the cut lands mid-rune here, so
+	// this also exercises the rune-boundary walk-back.
+	s := health.Snapshot{State: health.StateNotReady}
+	for range 400 {
+		s.Checks = append(s.Checks, check(strings.Repeat("日", 20), health.GroupCritical, health.StatusFail))
+	}
+
+	got := statusText(s)
+	if len(got) > maxStatusBytes {
+		t.Fatalf("statusText is %d bytes, want at most %d", len(got), maxStatusBytes)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("a capped line does not end in an ellipsis: %q", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("the cap cut a rune in half: %q", got)
+	}
+}
+
+func TestStatusIsOneLineOnTheWire(t *testing.T) {
+	// The end-to-end form: a hostile check name must not become a second
+	// systemd assignment in the datagram.
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("bad\nREADY=1\nWATCHDOG=1", failing("bad"))
+	waitState(t, reg, health.StateNotReady)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// The registry is not_ready, so this datagram is STATUS= alone: exactly one
+	// line. A looser bound would let a sanitiser regression inject MAINPID= or
+	// ERRNO= and still pass.
+	if got := recv(t, ln, time.Second); strings.Count(got, "\n") != 0 {
+		t.Fatalf("datagram %q contains %d newlines, want 0", got, strings.Count(got, "\n"))
+	}
+}
+
+func TestNoErrorTextLeaks(t *testing.T) {
+	// D1/D8: the property this transport must never break. Every state is
+	// driven, and the vacuity guard below is what makes the result mean
+	// something — a healthy registry would pass this test trivially.
+	addr, ln := notifySocket(t)
+
+	lg := &logCapture{}
+
+	reg := health.New(fastConfig(), lg.logger())
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("registry Start: %v", err)
+	}
+	stopAtCleanup(t, reg)
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// unknown: an empty registry has no verdict.
+	seen := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+
+	live, db, s3 := newToggle(errors.New(sentinel)), newToggle(errors.New(sentinel)), newToggle(errors.New(sentinel))
+	for _, tg := range []*toggle{live, db, s3} {
+		tg.fail()
+	}
+
+	reg.Liveness("live", live.check)
+	reg.Critical("db", db.check)
+	reg.Informational("s3", s3.check)
+	waitState(t, reg, health.StateNotReady)
+
+	// The vacuity guard. deriveState is first-match-wins, so the state proves
+	// only that *one* counting check is down — wait on the property actually
+	// being asserted instead, or a check still in its first run reads unknown.
+	waitFor(t, "all three checks to be failing", func() bool {
+		cs := reg.Snapshot().Checks
+		if len(cs) != 3 {
+			return false
+		}
+		for _, c := range cs {
+			if c.Status != health.StatusFail {
+				return false
+			}
+		}
+
+		return true
+	})
+
+	if !strings.Contains(lg.text(), sentinel) {
+		t.Fatal("the sentinel is not in the registry log either, so this test proves nothing")
+	}
+
+	seen = append(seen, recvAll(t, ln, 60*time.Millisecond, 2*time.Second)...)
+
+	// degraded: only the informational check is still red.
+	live.pass()
+	db.pass()
+	waitState(t, reg, health.StateDegraded)
+	seen = append(seen, recvAll(t, ln, 60*time.Millisecond, 2*time.Second)...)
+
+	s3.pass()
+	waitState(t, reg, health.StateReady)
+	seen = append(seen, recvAll(t, ln, 60*time.Millisecond, 2*time.Second)...)
+
+	db.fail()
+	waitState(t, reg, health.StateNotReady)
+	seen = append(seen, recvAll(t, ln, 60*time.Millisecond, 2*time.Second)...)
+
+	reg.Drain()
+	waitState(t, reg, health.StateStopping)
+	seen = append(seen, recvAll(t, ln, 60*time.Millisecond, 2*time.Second)...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := n.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	seen = append(seen, recvAll(t, ln, 60*time.Millisecond, 2*time.Second)...)
+
+	if len(seen) == 0 {
+		t.Fatal("no datagrams captured at all")
+	}
+	for _, d := range seen {
+		if strings.Contains(d, sentinel) {
+			t.Fatalf("a datagram leaks a check error: %q", d)
+		}
+	}
+}

--- a/infra/health/sdnotify/systemd.go
+++ b/infra/health/sdnotify/systemd.go
@@ -1,0 +1,143 @@
+// This file contains code adapted from github.com/coreos/go-systemd/v22 at
+// v22.7.0, files daemon/sdnotify.go and daemon/watchdog.go. It is copied
+// rather than imported so that this module keeps an empty require block; see
+// infra/health/go.mod.
+//
+// Copyright 2014 Docker, Inc.
+// Copyright 2015-2018 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The rest of this repository is MIT; see the repository root LICENSE.
+//
+// NOTICE, reproduced from the upstream NOTICE file:
+//
+//	CoreOS Project
+//	Copyright 2018 CoreOS, Inc
+//
+//	This product includes software developed at CoreOS, Inc.
+//	(http://www.coreos.com/).
+//
+// MODIFICATIONS by Webitel, 2026 (Apache License 2.0, section 4(b)):
+//
+//   - SdNotify is unexported as notify and takes the socket address as a
+//     parameter instead of reading NOTIFY_SOCKET on every call.
+//   - notify sets a write deadline before writing. Upstream has none; that
+//     gap is the reason this code is copied and modified rather than imported.
+//   - notify rewrites a leading '@' to NUL for Linux abstract sockets.
+//   - notify returns a plain error instead of (bool, error). New already
+//     handles the "NOTIFY_SOCKET is unset" case, so the bool carried no
+//     information at this call site.
+//   - The unsetEnvironment parameter is removed from both functions; this
+//     package never mutates the process environment.
+//   - SdWatchdogEnabled is unexported as watchdogEnabled, and range-checks
+//     WATCHDOG_USEC against maxWatchdogUsec. Upstream's strconv.Atoi lets a
+//     large value overflow the multiplication into a spin-loop period.
+//   - SdNotifyReloading, SdNotifyMonotonicUsec and the sdnotify_unix.go /
+//     sdnotify_other.go build-tagged pair are not copied. The first is unused
+//     here; the second needs golang.org/x/sys/unix, which this module must
+//     not depend on.
+//   - The SdNotify* constants are unexported and renamed to notifyReady,
+//     notifyStopping and notifyWatchdog.
+//   - notify wraps its socket errors with %w and a "health/sdnotify:" prefix.
+//     Upstream returns the bare *net.OpError.
+//   - The "NOTIFY_SOCKET is unset" early return is deleted. New owns that case
+//     and returns a nil *Notifier, so notify is never reached with an empty
+//     address.
+
+package sdnotify
+
+import (
+	"fmt"
+	"math"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	notifyReady    = "READY=1"
+	notifyStopping = "STOPPING=1"
+	notifyWatchdog = "WATCHDOG=1"
+)
+
+// maxWatchdogUsec is the largest WATCHDOG_USEC that survives the conversion to
+// a Duration. Beyond it the multiplication wraps, and a wrapped value lands
+// wherever it lands — a sub-microsecond period turns the loop into a spin loop
+// that floods the notify socket, which is worse than no watchdog at all.
+const maxWatchdogUsec = int64(math.MaxInt64) / int64(time.Microsecond)
+
+// notify sends one datagram to the systemd notify socket.
+func notify(addr, state string, timeout time.Duration) error {
+	// Belt and braces: Go's linux syscall layer accepts '@' and '\x00'
+	// identically (syscall/syscall_linux.go:547-577), so this is a no-op there.
+	// Abstract sockets do not exist off linux, where dialling an '@' address
+	// fails either way.
+	if strings.HasPrefix(addr, "@") {
+		addr = "\x00" + addr[1:]
+	}
+
+	socketAddr := &net.UnixAddr{
+		Name: addr,
+		Net:  "unixgram",
+	}
+
+	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	if err != nil {
+		return fmt.Errorf("health/sdnotify: dial %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetWriteDeadline(time.Now().Add(timeout))
+
+	if _, err = conn.Write([]byte(state)); err != nil {
+		return fmt.Errorf("health/sdnotify: write %s: %w", addr, err)
+	}
+
+	return nil
+}
+
+// watchdogEnabled returns the full WATCHDOG_USEC interval, or 0 when the
+// watchdog is not enabled for this process. The caller halves it.
+func watchdogEnabled() (time.Duration, error) {
+	wusec := os.Getenv("WATCHDOG_USEC")
+	wpid := os.Getenv("WATCHDOG_PID")
+
+	if wusec == "" {
+		return 0, nil
+	}
+	s, err := strconv.ParseInt(wusec, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error converting WATCHDOG_USEC: %w", err)
+	}
+	if s <= 0 || s > maxWatchdogUsec {
+		return 0, fmt.Errorf("error WATCHDOG_USEC out of range: %s", wusec)
+	}
+	interval := time.Duration(s) * time.Microsecond
+
+	if wpid == "" {
+		return interval, nil
+	}
+	p, err := strconv.Atoi(wpid)
+	if err != nil {
+		return 0, fmt.Errorf("error converting WATCHDOG_PID: %w", err)
+	}
+	if os.Getpid() != p {
+		return 0, nil
+	}
+
+	return interval, nil
+}

--- a/infra/health/sdnotify/watchdog_test.go
+++ b/infra/health/sdnotify/watchdog_test.go
@@ -1,0 +1,188 @@
+package sdnotify
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/webitel/webitel-go-kit/infra/health"
+)
+
+func TestWatchdogPings(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	t.Setenv("WATCHDOG_USEC", "20000") // period 10ms
+	t.Setenv("WATCHDOG_PID", "")
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	pings := 0
+	for range 20 {
+		d := recv(t, ln, time.Second)
+		if !strings.Contains(d, notifyWatchdog) {
+			continue
+		}
+		if d != notifyWatchdog {
+			t.Fatalf("a watchdog ping carries more than WATCHDOG=1: %q", d)
+		}
+
+		pings++
+		if pings == 2 {
+			return
+		}
+	}
+
+	t.Fatalf("watchdog pings = %d, want at least 2", pings)
+}
+
+func TestWatchdogGatedOnSchedulerAlive(t *testing.T) {
+	// D3: the ping tracks the registry's own scheduler, never a dependency, so
+	// one database outage cannot restart the whole fleet at once.
+	addr, ln := notifySocket(t)
+
+	cfg := fastConfig()
+	cfg.StaleAfter = 50 * time.Millisecond
+
+	reg := newTestRegistry(t, cfg)
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	t.Setenv("WATCHDOG_USEC", "20000")
+	t.Setenv("WATCHDOG_PID", "")
+
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := reg.Stop(ctx); err != nil {
+		t.Fatalf("registry Stop: %v", err)
+	}
+
+	waitFor(t, "the scheduler to go stale", func() bool { return !reg.Snapshot().SchedulerAlive })
+
+	recvAll(t, ln, 60*time.Millisecond, 2*time.Second) // drain what was in flight
+
+	got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	for _, d := range got {
+		if strings.Contains(d, notifyWatchdog) {
+			t.Fatalf("a ping after the scheduler went stale: %q", got)
+		}
+	}
+}
+
+func TestWatchdogPIDMismatch(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	t.Setenv("WATCHDOG_USEC", "20000")
+	t.Setenv("WATCHDOG_PID", strconv.Itoa(os.Getpid()+1))
+
+	lg := &logCapture{}
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond), WithLogger(lg.logger()))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	for _, d := range got {
+		if strings.Contains(d, notifyWatchdog) {
+			t.Fatalf("a ping with a mismatched WATCHDOG_PID: %q", got)
+		}
+	}
+
+	// A mismatch is silently disabled, not an error.
+	if errs := lg.errs(); len(errs) != 0 {
+		t.Fatalf("a PID mismatch logged errors: %v", errs)
+	}
+}
+
+func TestWatchdogMalformedEnv(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	t.Setenv("WATCHDOG_USEC", "not-a-number")
+	t.Setenv("WATCHDOG_PID", "")
+
+	lg := &logCapture{}
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond), WithLogger(lg.logger()))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if !strings.Contains(lg.text(), "WATCHDOG_USEC") {
+		t.Fatalf("the unusable WATCHDOG_USEC was not logged: %s", lg.text())
+	}
+
+	// A malformed environment disables the ping and nothing else.
+	got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	if want := notifyReady + "\nSTATUS=" + health.NameReady; countEqual(got, want) != 1 {
+		t.Fatalf("datagrams = %q, want exactly one %q", got, want)
+	}
+	for _, d := range got {
+		if strings.Contains(d, notifyWatchdog) {
+			t.Fatalf("a ping with an unusable WATCHDOG_USEC: %q", got)
+		}
+	}
+}
+
+func TestWatchdogUsecOutOfRange(t *testing.T) {
+	// WATCHDOG_USEC comes from outside this module. Unbounded, the conversion
+	// to a Duration wraps: 18446744073709552 used to yield a 192ns period, a
+	// spin loop dialling the notify socket millions of times a second.
+	t.Setenv("WATCHDOG_PID", "")
+
+	for _, v := range []string{"0", "-1", "9223372036854775807", "18446744073709552"} {
+		t.Setenv("WATCHDOG_USEC", v)
+
+		d, err := watchdogEnabled()
+		if err == nil || d != 0 {
+			t.Errorf("WATCHDOG_USEC=%s gave (%s, %v), want (0, an error)", v, d, err)
+		}
+	}
+}
+
+func TestWatchdogAbsent(t *testing.T) {
+	addr, ln := notifySocket(t)
+
+	reg := newTestRegistry(t, fastConfig())
+	reg.Critical("db", passing)
+	waitState(t, reg, health.StateReady)
+
+	t.Setenv("WATCHDOG_USEC", "")
+	t.Setenv("WATCHDOG_PID", "")
+
+	lg := &logCapture{}
+	n := newNotifier(t, reg, addr, WithPollInterval(10*time.Millisecond), WithLogger(lg.logger()))
+	if err := n.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got := recvAll(t, ln, 60*time.Millisecond, 2*time.Second)
+	for _, d := range got {
+		if strings.Contains(d, notifyWatchdog) {
+			t.Fatalf("a ping with no WATCHDOG_USEC: %q", got)
+		}
+	}
+	if errs := lg.errs(); len(errs) != 0 {
+		t.Fatalf("an absent watchdog logged errors: %v", errs)
+	}
+}

--- a/infra/health/snapshot.go
+++ b/infra/health/snapshot.go
@@ -1,0 +1,158 @@
+package health
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Snapshot is one consistent view of the registry, taken under a single lock.
+type Snapshot struct {
+	State          State         // verdict over liveness and critical; informational only degrades
+	Checks         []CheckResult // sorted by name; Err is for logs, never for bodies
+	SchedulerAlive bool          // the scheduler itself is still turning
+	Draining       bool          // Drain was called; one-way
+	Time           time.Time     // the single now used for staleness, grace, and this stamp
+}
+
+// Snapshot returns one consistent view of the registry, taken at a single instant.
+func (r *Registry) Snapshot() Snapshot {
+	if r == nil {
+		return Snapshot{State: StateUnknown, Time: time.Now()}
+	}
+
+	r.mu.Lock()
+	now := time.Now()
+	draining, stopped := r.draining, r.stopped
+	started, startedAt := r.started, r.startedAt
+	checks := make([]CheckResult, 0, len(r.checks))
+	for _, cs := range r.checks {
+		checks = append(checks, cs.result(now, r.cfg))
+	}
+	r.mu.Unlock()
+
+	slices.SortFunc(checks, func(a, b CheckResult) int { return strings.Compare(a.Name, b.Name) })
+
+	return Snapshot{
+		State:          deriveState(checks, draining, stopped),
+		Checks:         checks,
+		SchedulerAlive: schedulerAlive(now, checks, started, startedAt, r.cfg.StaleAfter),
+		Draining:       draining,
+		Time:           now,
+	}
+}
+
+// ReadyFunc returns the readiness verdict for service discovery. A false verdict
+// always carries a non-nil error: engine's Consul loop calls err.Error()
+// unconditionally on the not-ok branch.
+func (r *Registry) ReadyFunc() func() (bool, error) {
+	return func() (bool, error) {
+		s := r.Snapshot()
+		if s.State.Ready() {
+			return true, nil
+		}
+
+		return false, readyErr(s)
+	}
+}
+
+// readyErr synthesizes the verdict error from state tokens and check names only;
+// error texts stay in the logs. The string becomes the Consul TTL check note.
+func readyErr(s Snapshot) error {
+	if s.State == StateStopping {
+		return errors.New("health: stopping: shutting down")
+	}
+	if len(s.Checks) == 0 {
+		return errors.New("health: unknown: no checks registered")
+	}
+
+	var failing, unknown []string
+	for _, c := range s.Checks {
+		if !c.Group.countsForReadiness() {
+			continue
+		}
+		if c.Status == StatusFail {
+			failing = append(failing, c.Name)
+		}
+		if c.Status == StatusUnknown {
+			unknown = append(unknown, c.Name)
+		}
+	}
+
+	var parts []string
+	if len(failing) > 0 {
+		parts = append(parts, fmt.Sprintf("failing [%s]", strings.Join(failing, " ")))
+	}
+	if len(unknown) > 0 {
+		parts = append(parts, fmt.Sprintf("unknown [%s]", strings.Join(unknown, " ")))
+	}
+
+	// Only informational checks: nothing to list, so give the verdict a reason.
+	if len(parts) == 0 {
+		return errors.New("health: unknown: no liveness or critical checks registered")
+	}
+
+	return fmt.Errorf("health: %s: %s", s.State, strings.Join(parts, "; "))
+}
+
+// deriveState is the readiness verdict, ordered and first-match-wins. A stopped
+// registry is Stopping even without a Drain, so it never reports Ready while
+// shutting down.
+func deriveState(checks []CheckResult, draining, stopped bool) State {
+	if draining || stopped {
+		return StateStopping
+	}
+	if len(checks) == 0 {
+		return StateUnknown
+	}
+
+	var counting, failing, unknown, degraded bool
+	for _, c := range checks {
+		if c.Group.countsForReadiness() {
+			counting = true
+			failing = failing || c.Status == StatusFail
+			unknown = unknown || c.Status == StatusUnknown
+		} else if c.Status != StatusOK {
+			degraded = true
+		}
+	}
+
+	// Nothing answers "can this node take traffic?", so no verdict is earned —
+	// the same rule as an empty registry.
+	if !counting {
+		return StateUnknown
+	}
+	if failing {
+		return StateNotReady
+	}
+	if unknown {
+		return StateUnknown
+	}
+	if degraded {
+		return StateDegraded
+	}
+
+	return StateReady
+}
+
+// schedulerAlive says whether the scheduler is still turning: no checks means
+// nothing to observe, a fresh Start gets one StaleAfter of grace, then at least
+// one check must have completed a run within StaleAfter.
+func schedulerAlive(now time.Time, checks []CheckResult, started bool, startedAt time.Time, staleAfter time.Duration) bool {
+	if len(checks) == 0 {
+		return true
+	}
+	if started && now.Sub(startedAt) <= staleAfter {
+		return true
+	}
+
+	for _, c := range checks {
+		if !c.LastRun.IsZero() && now.Sub(c.LastRun) <= staleAfter {
+			return true
+		}
+	}
+
+	return false
+}

--- a/infra/health/snapshot.go
+++ b/infra/health/snapshot.go
@@ -17,7 +17,7 @@ type Snapshot struct {
 	Time           time.Time     // the single now used for staleness, grace, and this stamp
 }
 
-// Snapshot returns one consistent view of the registry, taken at a single instant.
+// Snapshot returns that view, taken at a single instant.
 func (r *Registry) Snapshot() Snapshot {
 	if r == nil {
 		return Snapshot{State: StateUnknown, Time: time.Now()}
@@ -44,9 +44,8 @@ func (r *Registry) Snapshot() Snapshot {
 	}
 }
 
-// ReadyFunc returns the readiness verdict for service discovery. A false verdict
-// always carries a non-nil error: engine's Consul loop calls err.Error()
-// unconditionally on the not-ok branch.
+// ReadyFunc returns the readiness verdict for service discovery. A false
+// verdict always carries a non-nil error.
 func (r *Registry) ReadyFunc() func() (bool, error) {
 	return func() (bool, error) {
 		s := r.Snapshot()
@@ -58,8 +57,7 @@ func (r *Registry) ReadyFunc() func() (bool, error) {
 	}
 }
 
-// readyErr synthesizes the verdict error from state tokens and check names only;
-// error texts stay in the logs. The string becomes the Consul TTL check note.
+// readyErr builds the verdict error from state tokens and check names only.
 func readyErr(s Snapshot) error {
 	if s.State == StateStopping {
 		return errors.New("health: stopping: shutting down")
@@ -89,7 +87,6 @@ func readyErr(s Snapshot) error {
 		parts = append(parts, fmt.Sprintf("unknown [%s]", strings.Join(unknown, " ")))
 	}
 
-	// Only informational checks: nothing to list, so give the verdict a reason.
 	if len(parts) == 0 {
 		return errors.New("health: unknown: no liveness or critical checks registered")
 	}
@@ -97,9 +94,7 @@ func readyErr(s Snapshot) error {
 	return fmt.Errorf("health: %s: %s", s.State, strings.Join(parts, "; "))
 }
 
-// deriveState is the readiness verdict, ordered and first-match-wins. A stopped
-// registry is Stopping even without a Drain, so it never reports Ready while
-// shutting down.
+// deriveState is the readiness verdict, ordered and first-match-wins.
 func deriveState(checks []CheckResult, draining, stopped bool) State {
 	if draining || stopped {
 		return StateStopping
@@ -119,8 +114,7 @@ func deriveState(checks []CheckResult, draining, stopped bool) State {
 		}
 	}
 
-	// Nothing answers "can this node take traffic?", so no verdict is earned —
-	// the same rule as an empty registry.
+	// Nothing answers "can this node take traffic?", so no verdict is earned.
 	if !counting {
 		return StateUnknown
 	}
@@ -137,9 +131,7 @@ func deriveState(checks []CheckResult, draining, stopped bool) State {
 	return StateReady
 }
 
-// schedulerAlive says whether the scheduler is still turning: no checks means
-// nothing to observe, a fresh Start gets one StaleAfter of grace, then at least
-// one check must have completed a run within StaleAfter.
+// schedulerAlive says whether the scheduler is still turning.
 func schedulerAlive(now time.Time, checks []CheckResult, started bool, startedAt time.Time, staleAfter time.Duration) bool {
 	if len(checks) == 0 {
 		return true

--- a/infra/health/snapshot_test.go
+++ b/infra/health/snapshot_test.go
@@ -1,0 +1,390 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cr builds a CheckResult for driving the pure derivation helpers.
+func cr(name string, group Group, status Status) CheckResult {
+	return CheckResult{Name: name, Group: group, Status: status}
+}
+
+func TestZeroSnapshotReadsUnknown(t *testing.T) {
+	// StateUnknown must be the iota-0 zero value: a zero Snapshot is never ready.
+	var s Snapshot
+
+	if s.State != StateUnknown {
+		t.Fatalf("zero Snapshot state is %s, want %s", s.State, NameUnknown)
+	}
+	if s.State.Ready() {
+		t.Fatal("zero Snapshot reports ready")
+	}
+}
+
+func TestStateNames(t *testing.T) {
+	for state, want := range map[State]string{
+		StateUnknown:  NameUnknown,
+		StateNotReady: NameNotReady,
+		StateDegraded: NameDegraded,
+		StateReady:    NameReady,
+		StateStopping: NameStopping,
+		State(200):    NameUnknown,
+	} {
+		if got := state.String(); got != want {
+			t.Errorf("State(%d) = %q, want %q", state, got, want)
+		}
+	}
+}
+
+func TestVerdictTable(t *testing.T) {
+	allOK := []CheckResult{
+		cr("db", GroupCritical, StatusOK),
+		cr("live", GroupLiveness, StatusOK),
+		cr("s3", GroupInformational, StatusOK),
+	}
+
+	for _, tt := range []struct {
+		name     string
+		checks   []CheckResult
+		draining bool
+		stopped  bool
+		want     State
+		ready    bool
+	}{
+		{"draining", allOK, true, false, StateStopping, false},
+		{"stopped without drain", allOK, false, true, StateStopping, false}, // E4
+		{"zero checks", nil, false, false, StateUnknown, false},
+		{"counting fail", []CheckResult{cr("db", GroupCritical, StatusFail)}, false, false, StateNotReady, false},
+		{"counting unknown", []CheckResult{cr("db", GroupCritical, StatusUnknown)}, false, false, StateUnknown, false},
+		{"informational fail only degrades", []CheckResult{cr("db", GroupCritical, StatusOK), cr("s3", GroupInformational, StatusFail)}, false, false, StateDegraded, true},
+		{"informational unknown only degrades", []CheckResult{cr("db", GroupCritical, StatusOK), cr("s3", GroupInformational, StatusUnknown)}, false, false, StateDegraded, true}, // E2/E3
+		{"all ok", allOK, false, false, StateReady, true},
+		{"fail outranks unknown", []CheckResult{cr("a", GroupCritical, StatusUnknown), cr("b", GroupLiveness, StatusFail)}, false, false, StateNotReady, false}, // E1
+		// Nothing registered answers "can this node take traffic?", so no verdict
+		// is earned — the same rule as an empty registry. These two rows used to
+		// assert ready/degraded, which was the defect: a registry holding only
+		// informational checks reported Ready before any of them had run.
+		{"only informational, all ok", []CheckResult{cr("s3", GroupInformational, StatusOK)}, false, false, StateUnknown, false},
+		{"only informational, one failing", []CheckResult{cr("s3", GroupInformational, StatusFail)}, false, false, StateUnknown, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveState(tt.checks, tt.draining, tt.stopped)
+			if got != tt.want {
+				t.Fatalf("state = %s, want %s", got, tt.want)
+			}
+			if got.Ready() != tt.ready {
+				t.Fatalf("%s.Ready() = %v, want %v", got, got.Ready(), tt.ready)
+			}
+		})
+	}
+}
+
+func TestSnapshotChecksAreSortedAndTimeIsStamped(t *testing.T) {
+	nop := func(context.Context) error { return nil }
+
+	reg := New(testConfig(), nil)
+	reg.Critical("b", nop)
+	reg.Liveness("a", nop)
+	reg.Informational("c", nop)
+
+	s := reg.Snapshot()
+	if s.Time.IsZero() {
+		t.Fatal("Snapshot.Time is zero")
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if s.Checks[i].Name != want {
+			t.Fatalf("Checks[%d] = %q, want %q", i, s.Checks[i].Name, want)
+		}
+	}
+
+	// results() is re-pointed at Snapshot().Checks; the two must agree.
+	res := reg.results()
+	if len(res) != len(s.Checks) {
+		t.Fatalf("results() has %d checks, Snapshot().Checks has %d", len(res), len(s.Checks))
+	}
+	for i := range res {
+		if res[i].Name != s.Checks[i].Name || res[i].Group != s.Checks[i].Group || res[i].Status != s.Checks[i].Status {
+			t.Fatalf("results()[%d] = %+v, want %+v", i, res[i], s.Checks[i])
+		}
+	}
+}
+
+func TestColdStartIsUnknownNotReady(t *testing.T) {
+	// E7: engine calls ReadyFunc synchronously at registration, before any
+	// check has completed a run — this is its very first production call.
+	release := make(chan struct{})
+	defer close(release)
+
+	reg := start(t, testConfig())
+	reg.Critical("db", func(context.Context) error { <-release; return nil })
+
+	if got := reg.Snapshot().State; got != StateUnknown {
+		t.Fatalf("cold-start state = %s, want %s", got, NameUnknown)
+	}
+
+	ok, err := reg.ReadyFunc()()
+	if ok {
+		t.Fatal("cold-start verdict is true, want false")
+	}
+	if err == nil {
+		t.Fatal("cold-start verdict carries a nil error")
+	}
+}
+
+func TestDrainFlipsTheSnapshotToStopping(t *testing.T) {
+	reg := New(testConfig(), nil)
+	reg.Drain()
+
+	s := reg.Snapshot()
+	if s.State != StateStopping {
+		t.Fatalf("state after Drain = %s, want %s", s.State, NameStopping)
+	}
+	if !s.Draining {
+		t.Fatal("Snapshot.Draining is false after Drain")
+	}
+}
+
+func TestStopWithoutDrainIsStopping(t *testing.T) {
+	// E4: Stop never sets draining, but a stopped registry must not report
+	// Ready for up to StaleAfter — stopped alone forces Stopping.
+	reg := New(testConfig(), nil)
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := reg.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	s := reg.Snapshot()
+	if s.State != StateStopping {
+		t.Fatalf("state after Stop = %s, want %s", s.State, NameStopping)
+	}
+	if s.Draining {
+		t.Fatal("Snapshot.Draining is true without a Drain")
+	}
+}
+
+// exact asserts the verdict error's whole text — the fixed strings engine
+// shows in the Consul UI.
+func exact(want string) func(*testing.T, error) {
+	return func(t *testing.T, err error) {
+		t.Helper()
+
+		if got := err.Error(); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestFalseVerdictAlwaysCarriesAnError(t *testing.T) {
+	// The reason this phase exists: engine/pkg/discovery/consul.go:129 calls
+	// err.Error() unconditionally on the not-ok branch, so (false, nil) panics
+	// the pilot consumer. Every false-producing configuration must pair the
+	// false with a non-nil error.
+	for _, tt := range []struct {
+		name  string
+		setup func(t *testing.T) *Registry
+		check func(t *testing.T, err error)
+	}{
+		{
+			name:  "nil registry",
+			setup: func(t *testing.T) *Registry { return nil },
+			check: exact("health: unknown: no checks registered"),
+		},
+		{
+			name:  "never started, zero checks",
+			setup: func(t *testing.T) *Registry { return New(testConfig(), nil) },
+			check: exact("health: unknown: no checks registered"),
+		},
+		{
+			name:  "started, zero checks",
+			setup: func(t *testing.T) *Registry { return start(t, testConfig()) },
+			check: exact("health: unknown: no checks registered"),
+		},
+		{
+			name: "cold start: check registered, first run not recorded",
+			setup: func(t *testing.T) *Registry {
+				release := make(chan struct{})
+
+				reg := start(t, testConfig())
+				// Registered after start, so LIFO cleanup releases the check
+				// before Stop tries to join it.
+				t.Cleanup(func() { close(release) })
+				reg.Critical("db", func(context.Context) error { <-release; return nil })
+
+				return reg
+			},
+			check: exact("health: unknown: unknown [db]"),
+		},
+		{
+			name: "critical failing",
+			setup: func(t *testing.T) *Registry {
+				reg := start(t, testConfig())
+				reg.Critical("db", func(context.Context) error { return errors.New("sentinel-dsn-secret") })
+				waitFor(t, "the check to fail", func() bool { return find(reg, "db").Status == StatusFail })
+
+				return reg
+			},
+			check: func(t *testing.T, err error) {
+				t.Helper()
+
+				// The synthesis rule, asserted: state token and check name in,
+				// the check's own error text never.
+				msg := err.Error()
+				if strings.Contains(msg, "sentinel-dsn-secret") {
+					t.Fatalf("verdict error leaks the check's error text: %q", msg)
+				}
+				if !strings.Contains(msg, NameNotReady) || !strings.Contains(msg, "db") {
+					t.Fatalf("got %q, want the %s token and the check name", msg, NameNotReady)
+				}
+			},
+		},
+		{
+			name: "critical unknown via staleness",
+			setup: func(t *testing.T) *Registry {
+				cfg := testConfig()
+				cfg.FailThreshold = 3
+				cfg.StaleAfter = 100 * time.Millisecond
+
+				var runs atomic.Int32
+				release := make(chan struct{})
+
+				reg := start(t, cfg)
+				t.Cleanup(func() { close(release) })
+				reg.Critical("db", func(context.Context) error {
+					if runs.Add(1) > 1 {
+						<-release // healthy once, then hangs forever
+					}
+
+					return nil
+				})
+
+				// Wait for OK first: a never-ran check is also unknown, and
+				// with the same message, so skipping this makes the subtest
+				// pass without the staleness transition ever happening.
+				waitFor(t, "the healthy first run", func() bool { return find(reg, "db").Status == StatusOK })
+				waitFor(t, "the result to go stale", func() bool { return find(reg, "db").Status == StatusUnknown })
+
+				return reg
+			},
+			check: exact("health: unknown: unknown [db]"),
+		},
+		{
+			name: "draining",
+			setup: func(t *testing.T) *Registry {
+				reg := New(testConfig(), nil)
+				reg.Drain()
+
+				return reg
+			},
+			check: exact("health: stopping: shutting down"),
+		},
+		{
+			name: "stopped",
+			setup: func(t *testing.T) *Registry {
+				reg := New(testConfig(), nil)
+				if err := reg.Stop(context.Background()); err != nil {
+					t.Fatalf("Stop: %v", err)
+				}
+
+				return reg
+			},
+			check: exact("health: stopping: shutting down"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := tt.setup(t)
+
+			fn := reg.ReadyFunc()
+			if fn == nil {
+				t.Fatal("ReadyFunc returned a nil closure")
+			}
+
+			ok, err := fn()
+			if ok {
+				t.Fatal("verdict is true, want false")
+			}
+			if err == nil {
+				t.Fatal("false verdict with a nil error — engine would panic on err.Error()")
+			}
+			tt.check(t, err)
+		})
+	}
+}
+
+func TestNilRegistrySnapshotIsSafe(t *testing.T) {
+	var reg *Registry
+
+	s := reg.Snapshot()
+	if s.State != StateUnknown {
+		t.Fatalf("nil-registry state = %s, want %s", s.State, NameUnknown)
+	}
+	if s.Time.IsZero() {
+		t.Fatal("nil-registry Snapshot.Time is zero")
+	}
+}
+
+func TestSchedulerAlive(t *testing.T) {
+	// D3, at both grace boundaries, driven with an explicit now.
+	now := time.Now()
+	stale := DefaultConfig().StaleAfter
+
+	neverRan := CheckResult{Name: "never"}
+	ranAt := func(at time.Time) CheckResult { return CheckResult{Name: "db", LastRun: at} }
+
+	for _, tt := range []struct {
+		name      string
+		checks    []CheckResult
+		started   bool
+		startedAt time.Time
+		want      bool
+	}{
+		{"zero checks, never started", nil, false, time.Time{}, true},
+		{"zero checks, started long ago", nil, true, now.Add(-time.Hour), true},
+		{"grace: started exactly StaleAfter ago, nothing ran", []CheckResult{neverRan}, true, now.Add(-stale), true},
+		{"grace over: started just past StaleAfter, nothing ran", []CheckResult{neverRan}, true, now.Add(-stale - time.Millisecond), false},
+		{"one run exactly StaleAfter ago", []CheckResult{neverRan, ranAt(now.Add(-stale))}, true, now.Add(-time.Hour), true},
+		{"all runs older than StaleAfter", []CheckResult{ranAt(now.Add(-stale - time.Millisecond))}, true, now.Add(-time.Hour), false},
+		{"never started, with checks", []CheckResult{neverRan}, false, time.Time{}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := schedulerAlive(now, tt.checks, tt.started, tt.startedAt, stale); got != tt.want {
+				t.Fatalf("schedulerAlive = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSchedulerAliveLifecycle(t *testing.T) {
+	reg := New(testConfig(), nil)
+	reg.Critical("db", func(context.Context) error { return nil })
+
+	// Never started with checks registered: nothing proves the scheduler turns.
+	if reg.Snapshot().SchedulerAlive {
+		t.Fatal("SchedulerAlive on a never-started registry with checks")
+	}
+
+	if err := reg.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		reg.Stop(ctx)
+	})
+
+	if !reg.Snapshot().SchedulerAlive {
+		t.Fatal("SchedulerAlive false inside the cold-start grace window")
+	}
+
+	waitFor(t, "a completed run", func() bool { return !find(reg, "db").LastRun.IsZero() })
+
+	if !reg.Snapshot().SchedulerAlive {
+		t.Fatal("SchedulerAlive false with a run completed within StaleAfter")
+	}
+}


### PR DESCRIPTION
Новий модуль `infra/health` — спільний реєстр перевірок здоров'я. Реєстр крутить перевірки у фоні, транспорти читають готовий результат: HTTP (`/livez`, `/readyz`, `/healthz`) і systemd `sd_notify`.

Дизайн: [infra/health — архітектура (WTEL-10088)](https://webitel.atlassian.net/wiki/spaces/BD/pages/1890091038/infra+health+WTEL-10088)

Нуль залежностей (тільки stdlib), 129 тестів з `-race`. Підключення до engine — WTEL-10090.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable background health checks with liveness, readiness, critical, and informational states.
  * Added readiness snapshots, failure tracking, stale-result handling, graceful draining, and bounded shutdown.
  * Added HTTP liveness, readiness, and health endpoints with text/JSON responses and secure verbose access.
  * Added systemd readiness, status, shutdown, and watchdog notifications.
* **Documentation**
  * Added usage guidance for health monitoring, HTTP probes, and systemd integration.
* **Tests**
  * Added comprehensive lifecycle, concurrency, race, serialization, and failure-handling coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->